### PR TITLE
fix: correct Airflow architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,18 +149,18 @@ See [Test Data Guide](docs/guides/test-data.md) for details.
 │                      │    │                                                       │
 │  Zookeeper (:2181)   │    │  Spark 4.0 (:7077, UI :8080)                         │
 │                      │    │  Spark 4.1 (:7078, UI :8082)                         │
-│  (direct to Spark,   │    └──────────────────────────┬────────────────────────────┘
-│   not via catalog)   │                               │
-└──────────────────────┘                               │ Iceberg API
-                                                       │
-┌──────────────────────┐                               │
-│  ORCHESTRATION       │                               │
-│                      │───────────────────────────────┤
-│  Airflow (:8085)     │  Schedules Spark jobs,        │
-│  └─ DAGs             │  Iceberg maintenance          │
-│  └─ Sensors          │                               │
-└──────────────────────┘                               │
-                                                       ▼
+│  (direct to Spark,   │    └───────────────────────────────────────────┬──────────┘
+│   not via catalog)   │                        ▲                       │
+└──────────────────────┘                        │                       │ Iceberg API
+                                                │ docker exec           │
+┌──────────────────────┐                        │ spark-submit          │
+│  ORCHESTRATION       │────────────────────────┘                       │
+│                      │                                                │
+│  Airflow (:8085)     │  (Airflow schedules Spark jobs;                │
+│  └─ DAGs             │   Spark talks to Iceberg)                      │
+│  └─ Sensors          │                                                │
+└──────────────────────┘                                                │
+                                                                        ▼
                             ┌───────────────────────────────────────────────────────┐
                             │                 CATALOG: Iceberg Metadata             │
                             │                                                       │
@@ -186,8 +186,9 @@ See [Test Data Guide](docs/guides/test-data.md) for details.
 **How It Works:**
 1. **Streaming** → Kafka feeds events directly to Spark (not via catalog)
 2. **Compute** → Spark transforms data through Bronze → Silver → Gold layers
-3. **Catalog** → PostgreSQL or Unity Catalog manages Iceberg table metadata
-4. **Storage** → SeaweedFS stores Parquet files accessed via Iceberg
+3. **Orchestration** → Airflow schedules Spark jobs via `docker exec spark-submit`
+4. **Catalog** → PostgreSQL or Unity Catalog manages Iceberg table metadata
+5. **Storage** → SeaweedFS stores Parquet files accessed via Iceberg
 
 **Catalog Options:**
 | Feature | PostgreSQL JDBC | Unity Catalog |

--- a/docs/guides/airflow.md
+++ b/docs/guides/airflow.md
@@ -16,18 +16,24 @@ This setup uses **Airflow 3.1.6** with Python 3.12. See [Airflow 3.x Notes](#air
 │  └─────────────┘  └─────────────┘  └─────────────────────┘   │
 └──────────────────────────────────────────────────────────────┘
          │                   │                    │
+         │ docker exec       │ Kafka sensors      │ Airflow DB
+         │ spark-submit      │ (wait for data)    │ (task state)
          ▼                   ▼                    ▼
 ┌─────────────┐      ┌─────────────┐      ┌─────────────┐
 │    Spark    │      │    Kafka    │      │  PostgreSQL │
-│  4.0 / 4.1  │      │   Sensors   │      │  (metadata) │
+│  4.0 / 4.1  │      │   Broker    │      │ (Airflow's) │
 └─────────────┘      └─────────────┘      └─────────────┘
          │
+         │ Spark talks to
+         │ Iceberg catalog
          ▼
 ┌─────────────────────────────────────────┐
 │              Iceberg Tables             │
 │  bronze.* → silver.* → gold.*           │
 └─────────────────────────────────────────┘
 ```
+
+**Key point**: Airflow orchestrates Spark jobs via `docker exec spark-submit`. Airflow does not talk directly to Iceberg - Spark handles all Iceberg operations.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Fixes misleading architecture diagrams that suggested Airflow talks directly to Iceberg.

**Actual flow:**
```
Airflow → (docker exec spark-submit) → Spark → Iceberg
```

Airflow orchestrates Spark jobs using BashOperator. Spark handles all Iceberg operations.

## Changes

- **README.md**: Updated main architecture diagram to show Airflow connecting to Spark, not the Iceberg API line
- **docs/guides/airflow.md**: Added labels to architecture diagram clarifying the connection types

## Test plan

- [ ] Diagrams render correctly in markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)