### PR TITLE
Bumped the Docker image tag of UC to v0.4.0

### DIFF
--- a/docker-compose-unity-catalog.yml
+++ b/docker-compose-unity-catalog.yml
@@ -14,7 +14,7 @@
 
 services:
   unity-catalog:
-    image: unitycatalog/unitycatalog:0.3.1
+    image: unitycatalog/unitycatalog:v0.4.0
     container_name: unity-catalog
     ports:
       - "8080:8080"      # REST API + Iceberg REST Catalog endpoint

--- a/docker-compose-unity-catalog.yml
+++ b/docker-compose-unity-catalog.yml
@@ -21,9 +21,12 @@ services:
     environment:
       - JAVA_OPTS=-Xmx2g
     volumes:
-      - ./config/unity-catalog:/opt/unitycatalog/etc/conf
-      - uc-data:/opt/unitycatalog/etc/db
-      - uc-logs:/opt/unitycatalog/etc/logs
+      #- ./config/unity-catalog:/opt/unitycatalog/etc/conf
+      - type: bind
+        source: ./config/unity-catalog/server.properties
+        target: /home/unitycatalog/etc/conf/server.properties
+      #- uc-data:/home/unitycatalog/etc/db
+      - uc-logs:/home/unitycatalog/etc/logs
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/api/2.1/unity-catalog/catalogs"]
       interval: 30s


### PR DESCRIPTION
As of mid-April 2026, v0.4.0 is the latest release of Unity Catalog on Docker Hub.
* UC on Docker Hub: https://hub.docker.com/r/unitycatalog/unitycatalog/tags?name=0.4.0
* UC releases: https://github.com/unitycatalog/unitycatalog/releases - There is a 0.4.1 tag, but not yet the corresponding Git release and Docker Hub image
