### PR TITLE
Improved support of MacOS (wrt df tool) in the lakehouse utility

### DIFF
--- a/lakehouse
+++ b/lakehouse
@@ -1265,7 +1265,7 @@ cmd_setup() {
 
     # Step 7: Check disk space
     echo -e "\n${YELLOW}6. Checking disk space...${NC}"
-    local free_gb=$(gdf -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
+    local free_gb=$($DF_TOOL -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
     if [ "$free_gb" -lt 10 ] 2>/dev/null; then
         echo -e "${YELLOW}!${NC} Low disk space: ${free_gb}GB free (10GB+ recommended)"
     else

--- a/lakehouse
+++ b/lakehouse
@@ -19,6 +19,19 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Check for GNU tools, when on MacOS
+# See also https://github.com/cloud-helpers/k8s-job-wrappers/tree/main/setGnuTools.sh
+export DF_TOOL="df"
+check_gnutools_on_macos() {
+	DF_TOOL="gdf"
+	if [ ! $(command -v $DF_TOOL) ]
+	then
+        echo -e "${RED}Missing GNU tools on MacOS:${NC}"
+        echo -e "  ${RED}✗${NC} $DF_TOOL"
+		return 1
+	fi
+}
+
 # Check if a command exists
 check_cmd() {
     command -v "$1" >/dev/null 2>&1
@@ -1133,8 +1146,21 @@ cmd_setup() {
     header "LAKEHOUSE SETUP"
     local has_errors=0
 
-    # Step 1: Check prerequisites
-    echo -e "\n${YELLOW}1. Checking prerequisites...${NC}"
+    # Step 1.1: Check for GNU tools, when on MacOS
+	if [ -f /usr/bin/sw_vers ]
+	then	
+		echo -e "\n${YELLOW}1.1. Checking for GNU tools when on MacOS...${NC}"
+		if ! check_gnutools_on_macos; then
+			echo -e "\n${RED}Please install GNU tools on MacOS before continuing.${NC}"
+			echo "See SETUP.md for installation instructions."
+			has_errors=1
+		else
+			echo -e "${GREEN}✓ All required tools installed when on MacOS${NC}"
+		fi
+	fi
+
+    # Step 1.2: Check prerequisites
+    echo -e "\n${YELLOW}1.2. Checking prerequisites...${NC}"
     if ! check_prerequisites; then
         echo -e "\n${RED}Please install missing tools before continuing.${NC}"
         echo "See SETUP.md for installation instructions."
@@ -1239,7 +1265,7 @@ cmd_setup() {
 
     # Step 7: Check disk space
     echo -e "\n${YELLOW}6. Checking disk space...${NC}"
-    local free_gb=$(df -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
+    local free_gb=$(gdf -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
     if [ "$free_gb" -lt 10 ] 2>/dev/null; then
         echo -e "${YELLOW}!${NC} Low disk space: ${free_gb}GB free (10GB+ recommended)"
     else


### PR DESCRIPTION
On MacOS, a few CLI (Command-Line) tools do not behave exactly like on Linux, where GNU tools are usually installed by default. There is a small Shell script, namely https://github.com/cloud-helpers/k8s-job-wrappers/tree/main/setGnuTools.sh , which setups correctly these CLI tools on MacOS as well.

For the lakehouse CLI utility, in this pull request (PR), only the `df` tool has been considered, and sourcing setGnuTools.sh is therefore not necessary. You may consider sourcing it (or just copy it in this repository, if you prefer; the license is very liberal, namely MIT).
