### PR TITLE
Adding browsedata command in the lakehouse utility

### DIFF
--- a/lakehouse
+++ b/lakehouse
@@ -37,6 +37,11 @@ check_cmd() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Browse Iceberg data
+browse_tables() {
+	docker exec -it spark-master-41 sh -c "/opt/spark/bin/spark-sql -e \"select * from iceberg.bronze.orders limit 10;\""
+}
+
 # Setup PostgreSQL database (create if not exists)
 setup_postgres() {
     local pg_user="${POSTGRES_USER:-postgres}"
@@ -1313,6 +1318,7 @@ cmd_help() {
     echo "  producer            Start Kafka event producer"
     echo "  consumer            Start Spark streaming consumer"
     echo "  testdata <cmd>      Test data generation (generate|stream|load|stats|clean)"
+    echo "  browsedata          Browse Iceberg tables, if any"
     echo "  help                Show this help"
     echo ""
     echo "Options:"
@@ -1364,6 +1370,7 @@ cmd_help() {
     echo "  lakehouse start unity-catalog"
     echo "  lakehouse testdata generate --days 30"
     echo "  lakehouse testdata stream --speed 100"
+    echo "  lakehouse browsedata"
 }
 
 # Main
@@ -1412,6 +1419,9 @@ case ${1:-help} in
     testdata)
         cmd_testdata "${@:2}"
         ;;
+	browsedata)
+		browse_tables
+		;;
     help|*)
         cmd_help
         ;;

--- a/lakehouse
+++ b/lakehouse
@@ -39,7 +39,8 @@ check_cmd() {
 
 # Browse Iceberg data
 browse_tables() {
-	docker exec -it spark-master-41 sh -c "/opt/spark/bin/spark-sql -e \"select * from iceberg.bronze.orders limit 10;\""
+    local table="${1:-iceberg.bronze.orders}"
+    docker exec -it spark-master-41 sh -c "/opt/spark/bin/spark-sql -e \"select * from ${table} limit 10;\""
 }
 
 # Setup PostgreSQL database (create if not exists)
@@ -1318,7 +1319,7 @@ cmd_help() {
     echo "  producer            Start Kafka event producer"
     echo "  consumer            Start Spark streaming consumer"
     echo "  testdata <cmd>      Test data generation (generate|stream|load|stats|clean)"
-    echo "  browsedata          Browse Iceberg tables, if any"
+    echo "  browsedata [table]  Browse Iceberg table rows (default: iceberg.bronze.orders)"
     echo "  help                Show this help"
     echo ""
     echo "Options:"
@@ -1371,6 +1372,7 @@ cmd_help() {
     echo "  lakehouse testdata generate --days 30"
     echo "  lakehouse testdata stream --speed 100"
     echo "  lakehouse browsedata"
+    echo "  lakehouse browsedata iceberg.gold.hourly_metrics"
 }
 
 # Main
@@ -1419,9 +1421,9 @@ case ${1:-help} in
     testdata)
         cmd_testdata "${@:2}"
         ;;
-	browsedata)
-		browse_tables
-		;;
+    browsedata)
+        browse_tables "$2"
+        ;;
     help|*)
         cmd_help
         ;;


### PR DESCRIPTION
Added a (still very simple) command, in the `lakehouse` utility, to browse Iceberg tables. It is rather a proof-of-concept/placeholder for a better command. However, it already works like that.