### PR TITLE
chore: harden .gitignore for generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Credentials and Secrets
 config/spark/spark-defaults.conf
 config/spark/spark-defaults-uc.conf
+config/spark/spark-defaults-delta.conf
 config/unity-catalog/server.properties
 .env
 .env.*
@@ -23,8 +24,9 @@ aws-credentials*
 
 # JAR files (use scripts/download-jars.sh to get files)
 jars/*.jar
+jars/*.jar.[0-9]*
 
-# data directories
+# Data directories
 /data/
 
 # IDE
@@ -40,6 +42,10 @@ __pycache__/
 *.pyc
 .ipynb_checkpoints/
 .venv/
+.coverage
+.coverage.*
+.pytest_cache/
+.ruff_cache/
 
 # Loose JAR files at root (should be in jars/)
 /*.jar
@@ -48,6 +54,16 @@ __pycache__/
 spark-warehouse/
 metastore_db/
 derby.log
+ivy-cache/
+
+# MLflow
+mlruns/
+mlartifacts/
+
+# Benchmark outputs (keep harness tracked, outputs local)
+benchmarks/results/*.json
+benchmarks/results/pipelines/*.json
+!benchmarks/results/.gitkeep
 
 # OS
 .DS_Store
@@ -56,8 +72,6 @@ Thumbs.db
 # Logs
 *.log
 logs/
-*.swo
-*.swp
 
 # Airflow
 logs/airflow/
@@ -69,3 +83,11 @@ terraform/*.tfstate
 terraform/*.tfstate.backup
 terraform/.terraform.lock.hcl
 terraform/terraform.tfvars
+terraform-databricks/.terraform/
+terraform-databricks/*.tfstate
+terraform-databricks/*.tfstate.backup
+terraform-databricks/.terraform.lock.hcl
+terraform-databricks/terraform.tfvars
+
+# Claude Code local agent configs (per-machine)
+.claude/agents/


### PR DESCRIPTION
## Summary
- Add coverage, MLflow runs, benchmark JSON outputs, ivy cache, `.jar.N` dupes, terraform-databricks state, and local Claude agent configs to `.gitignore`
- Also ignores new `spark-defaults-delta.conf` so users can override without risk of leaking to git
- Paired with local cleanup of untracked orphans (Spark 3.5 / HMS / ANSI-demo experiments, dupe jar, `_load_to_iceberg*` dead scripts) in working trees — those never hit git

## Why
Orphaned artifacts (`.coverage`, `mlruns/`, benchmark result JSONs) regularly appeared in `git status` during dev, and the Spark 3.5 / HMS experimental branch left stale configs around. This stops the bleeding.

## Test plan
- [ ] `git status` in a fresh worktree after running `pytest` and a benchmark shows no artifacts
- [ ] No currently-tracked files become accidentally ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)