### PR TITLE
refactor: bring OA demos forward as de-showed building blocks

### DIFF
--- a/scripts/demos/README.md
+++ b/scripts/demos/README.md
@@ -1,3 +1,15 @@
+# Demos
+
+## What's here
+
+| Suite | Purpose |
+|-------|---------|
+| [`showcase/`](showcase/README.md) | One-script-per-stack-component building blocks (Iceberg, UC, SDP, RTM, Airflow, Connect, K8s) |
+| [`mlflow-agents/`](mlflow-agents/README.md) | Reference MLflow AI Gateway agents that manage the lakehouse |
+| [`transformations/`](transformations/) + the rest of this file | 5-minute Spark Declarative Pipelines walkthrough with voiceover script |
+
+---
+
 # Spark Declarative Pipelines Demo
 
 A 5-minute demo showcasing Spark 4.1's Declarative Pipelines feature.

--- a/scripts/demos/mlflow-agents/README.md
+++ b/scripts/demos/mlflow-agents/README.md
@@ -1,0 +1,46 @@
+# MLflow Agent Demos
+
+Three reference agents that use MLflow's AI Gateway, Tracing, and Model
+Registry to manage the lakehouse. Each is a standalone FastAPI service
+that wraps a `ResponsesAgent` with a tool set scoped to lakehouse
+operations.
+
+## Prerequisites
+
+```bash
+pip install mlflow>=3.1 openai pyspark
+./lakehouse start all            # Spark, Kafka, UC
+docker compose -f docker-compose-mlflow.yml up -d  # Tracking + Gateway
+./lakehouse testdata generate --days 7
+./lakehouse testdata load
+```
+
+The agents default to Ollama (local OSS) via the Gateway's OpenAI-compatible
+API. To switch to Anthropic, set `MLFLOW_GATEWAY_MODEL=anthropic/claude-opus-4-7`
+(or whichever route you configured in `config/mlflow/gateway-config.yml`).
+
+## Agents
+
+| Agent | Role |
+|-------|------|
+| `guardian.py` | Pipeline Guardian — inspects Iceberg table health, checks data quality, triggers maintenance (compaction, snapshot expiry) |
+| `analyst.py` | Analyst — answers business questions over the gold layer using SQL |
+| `autopilot.py` | Autopilot — orchestrates multiple tools to diagnose and remediate pipeline issues end-to-end |
+
+## Running
+
+```bash
+python scripts/demos/mlflow-agents/guardian.py
+python scripts/demos/mlflow-agents/analyst.py
+python scripts/demos/mlflow-agents/autopilot.py
+```
+
+Or serve an agent as a registered MLflow model:
+
+```bash
+mlflow models serve -m runs:/<run_id>/guardian_agent -p 5001
+```
+
+All LLM calls are routed through the MLflow AI Gateway and traced via MLflow
+Tracing (OpenTelemetry). Agent artifacts are registered in the Unity Catalog
+model registry.

--- a/scripts/demos/mlflow-agents/analyst.py
+++ b/scripts/demos/mlflow-agents/analyst.py
@@ -236,7 +236,7 @@ def run_demo():
     tracking_available = False
     try:
         mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
-        mlflow.set_experiment("overarchitected-analyst")
+        mlflow.set_experiment("lakehouse-analyst")
         tracking_available = True
     except Exception:
         print("  MLflow tracking server not available — running without tracking.")

--- a/scripts/demos/mlflow-agents/analyst.py
+++ b/scripts/demos/mlflow-agents/analyst.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+MLflow Data Quality Analyst Agent
+==========================================================
+
+Option B: Natural language → Spark SQL → results.
+"What's the delivery performance in San Francisco this week?"
+
+Architecture:
+  User question → LLM generates SQL → Spark executes → LLM formats answer
+  All traced via MLflow. Served via MLflow Agent Server.
+
+Run:
+    python scripts/demos/mlflow-agents/analyst.py
+
+Prerequisites:
+    pip install mlflow>=3.1 openai pyspark
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+import os
+import json
+import uuid
+from datetime import datetime
+
+import mlflow
+from mlflow.pyfunc import ChatAgent
+from mlflow.types.agent import (
+    ChatAgentMessage,
+    ChatAgentResponse,
+)
+
+from pyspark.sql import SparkSession
+
+
+# ─── Configuration ──────────────────────────────────────────
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+SPARK_REMOTE = os.getenv("SPARK_REMOTE", None)
+SPARK_MASTER = os.getenv("SPARK_MASTER", "local[*]")
+LLM_MODEL = os.getenv("LLM_MODEL", "qwen3-coder:30b")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def get_spark():
+    if SPARK_REMOTE:
+        return SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
+    return SparkSession.builder \
+        .master(SPARK_MASTER) \
+        .appName("MLflow-Analyst-Agent") \
+        .getOrCreate()
+
+
+# ─── Schema Context ─────────────────────────────────────────
+def get_schema_context():
+    """Build schema context string for the LLM."""
+    spark = get_spark()
+    schemas = {}
+
+    tables = [
+        "iceberg.bronze.orders",
+        "iceberg.bronze.dim_locations",
+        "iceberg.bronze.dim_brands",
+        "iceberg.bronze.dim_items",
+        "iceberg.bronze.dim_categories",
+    ]
+
+    for table in tables:
+        try:
+            df = spark.table(table)
+            cols = [(c.name, c.dataType.simpleString()) for c in df.schema]
+            count = df.count()
+            schemas[table] = {"columns": cols, "row_count": count}
+        except Exception:
+            pass
+
+    context = "Available tables:\n"
+    for table, info in schemas.items():
+        context += f"\n{table} ({info['row_count']:,} rows):\n"
+        for col_name, col_type in info["columns"]:
+            context += f"  - {col_name}: {col_type}\n"
+
+    context += """
+Notes on the data:
+- orders.ts is ISO 8601 string (e.g., '2024-01-15T12:00:00'). Use TO_TIMESTAMP(REPLACE(ts, 'T', ' ')) to convert.
+- orders.body is a JSON string. Use get_json_object(body, '$.field') to extract fields.
+- orders.event_type values: order_created, kitchen_started, kitchen_finished, order_ready, driver_arrived, driver_picked_up, driver_ping, delivered
+- orders.sequence: 0 for order_created, increases through lifecycle
+- body fields vary by event_type:
+  - order_created: brand_id, total, items (array)
+  - delivered: delivery_lat, delivery_lon, total_mins
+  - driver_ping: lat, lon, progress_pct
+- dim_locations: id, city, lat, lon
+- dim_brands: id, name, cuisine_type, avg_prep_time_mins, momentum
+"""
+    return context
+
+
+SYSTEM_PROMPT_TEMPLATE = """You are a Data Quality Analyst for a food delivery lakehouse (Casper's Kitchen).
+You answer questions about the data by writing and executing Spark SQL queries.
+
+{schema_context}
+
+Rules:
+1. Always use the query_lakehouse tool to run SQL — never guess at data.
+2. Write efficient SQL — use LIMIT, avoid SELECT *.
+3. For timestamps, always use: TO_TIMESTAMP(REPLACE(ts, 'T', ' '))
+4. For JSON extraction, use: get_json_object(body, '$.field')
+5. Be concise and technical. Include the SQL you ran in your answer.
+6. If a query fails, explain why and try a different approach.
+"""
+
+
+# ─── Tool ───────────────────────────────────────────────────
+def query_lakehouse(sql: str) -> dict:
+    """Execute SQL against the lakehouse and return results."""
+    spark = get_spark()
+    result = {"sql": sql}
+
+    try:
+        df = spark.sql(sql)
+        rows = df.limit(50).collect()
+        result["columns"] = df.columns
+        result["row_count"] = len(rows)
+        result["data"] = [row.asDict() for row in rows]
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+TOOL_SCHEMAS = [{
+    "type": "function",
+    "function": {
+        "name": "query_lakehouse",
+        "description": "Execute a Spark SQL query against the Iceberg lakehouse. Returns up to 50 rows.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "sql": {"type": "string", "description": "The SQL query to execute"}
+            },
+            "required": ["sql"]
+        }
+    }
+}]
+
+
+# ─── Agent ──────────────────────────────────────────────────
+class DataAnalystAgent(ChatAgent):
+    """Natural language → SQL → answer agent."""
+
+    def __init__(self):
+        self._client = None
+        self._schema_context = None
+
+    @property
+    def schema_context(self):
+        if self._schema_context is None:
+            self._schema_context = get_schema_context()
+        return self._schema_context
+
+    @property
+    def client(self):
+        if self._client is None:
+            import openai
+            self._client = openai.OpenAI(base_url=OLLAMA_BASE_URL, api_key="ollama")
+        return self._client
+
+    def _call_llm(self, messages, tools=None):
+        """Call the LLM via OpenAI-compatible API (Ollama)."""
+        system = SYSTEM_PROMPT_TEMPLATE.format(schema_context=self.schema_context)
+        kwargs = {
+            "model": LLM_MODEL, "max_tokens": 4096,
+            "messages": [{"role": "system", "content": system}] + messages,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        return self.client.chat.completions.create(**kwargs)
+
+    def _extract_response(self, response):
+        """Extract text and tool calls from OpenAI-compatible response."""
+        msg = response.choices[0].message
+        tool_calls = []
+        if msg.tool_calls:
+            for tc in msg.tool_calls:
+                tool_calls.append({"id": tc.id, "name": tc.function.name,
+                                   "arguments": json.loads(tc.function.arguments)})
+        return msg.content or "", tool_calls
+
+    @mlflow.trace
+    def predict(self, messages, context=None, custom_inputs=None):
+        conv = [{"role": m.role, "content": m.content} for m in messages]
+        all_text = []
+
+        for _ in range(8):
+            response = self._call_llm(conv, tools=TOOL_SCHEMAS)
+            text, tool_calls = self._extract_response(response)
+
+            if text:
+                all_text.append(text)
+
+            if not tool_calls:
+                break
+
+            # Execute tools (OpenAI-compatible format)
+            conv.append({"role": "assistant", "content": text,
+                         "tool_calls": [{"id": tc["id"], "type": "function",
+                                         "function": {"name": tc["name"],
+                                                      "arguments": json.dumps(tc["arguments"])}}
+                                        for tc in tool_calls]})
+            for tc in tool_calls:
+                with mlflow.start_span(name=f"sql:{tc['name']}") as span:
+                    span.set_inputs(tc["arguments"])
+                    result = query_lakehouse(**tc["arguments"])
+                    span.set_outputs(result)
+                conv.append({"role": "tool", "tool_call_id": tc["id"],
+                             "content": json.dumps(result, default=str)})
+
+        return ChatAgentResponse(
+            messages=[ChatAgentMessage(role="assistant", content="\n".join(all_text), id=str(uuid.uuid4()))]
+        )
+
+
+# ─── Demo ───────────────────────────────────────────────────
+def run_demo():
+    section("MLflow Data Quality Analyst Agent")
+
+    tracking_available = False
+    try:
+        mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+        mlflow.set_experiment("overarchitected-analyst")
+        tracking_available = True
+    except Exception:
+        print("  MLflow tracking server not available — running without tracking.")
+
+    if tracking_available:
+        try:
+            mlflow.openai.autolog()
+        except Exception:
+            pass
+
+    agent = DataAnalystAgent()
+
+    demo_queries = [
+        "What's the total order volume by city? Which city has the most orders?",
+        "What are the peak ordering hours? Show me the hourly distribution.",
+        "Which brands have the highest average order value? Top 5.",
+        "What percentage of orders have null or missing body data?",
+        "What's the average delivery time by city? Which city is fastest?",
+    ]
+
+    print(f"\n  LLM Provider: {LLM_PROVIDER}")
+    print(f"  LLM Model: {LLM_MODEL}")
+
+    for i, query in enumerate(demo_queries, 1):
+        print(f"\n{'═' * 60}")
+        print(f"  Question {i}: {query}")
+        print(f"{'═' * 60}")
+
+        try:
+            mlflow.end_run()  # ensure no stale run
+            run_ctx = mlflow.start_run(run_name=f"analyst_demo_{i}") if tracking_available else None
+            if run_ctx:
+                run_ctx.__enter__()
+            response = agent.predict(
+                messages=[ChatAgentMessage(role="user", content=query)]
+            )
+            print(f"\n  Answer:")
+            print(f"  {'-' * 50}")
+            for msg in response.messages:
+                for line in msg.content.split("\n"):
+                    print(f"  {line}")
+            if run_ctx:
+                run_ctx.__exit__(None, None, None)
+        except Exception as e:
+            print(f"  Error: {e}")
+            import traceback; traceback.print_exc()
+
+    if tracking_available:
+        section("Logging Agent to MLflow")
+        try:
+            with mlflow.start_run(run_name="analyst_agent_registration"):
+                mlflow.pyfunc.log_model(
+                    artifact_path="analyst_agent",
+                    python_model=agent,
+                    registered_model_name="data-analyst",
+                )
+                print("  Agent logged as 'data-analyst'")
+        except Exception as e:
+            print(f"  Could not log model: {e}")
+
+
+def main():
+    print("\n" + "=" * 60)
+    print("  DATA QUALITY ANALYST AGENT")
+    print("  Ask questions in English. Get SQL + answers.")
+    print("=" * 60)
+
+    run_demo()
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/mlflow-agents/autopilot.py
+++ b/scripts/demos/mlflow-agents/autopilot.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""
+MLflow Pipeline Autopilot Agent
+========================================================
+
+Option C (ambitious): An agent that monitors streaming pipeline health,
+detects anomalies, and takes corrective action.
+
+Architecture:
+  Monitoring loop → Agent checks metrics → Decides actions → Executes
+  - Throughput monitoring (events/sec)
+  - Latency tracking (processing delay)
+  - Data quality anomalies (null spikes, schema drift)
+  - Auto-maintenance (compaction when file count is high)
+  - Alerting (when metrics exceed thresholds)
+
+This is the most complex option. It ties together:
+  Spark + Iceberg + Kafka + Airflow + MLflow
+
+Run:
+    python scripts/demos/mlflow-agents/autopilot.py
+
+    # Or in continuous monitoring mode:
+    python scripts/demos/mlflow-agents/autopilot.py --monitor
+
+Prerequisites:
+    pip install mlflow>=3.1 openai pyspark
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+import os
+import sys
+import json
+import time
+import uuid
+from datetime import datetime, timedelta
+
+import mlflow
+from mlflow.pyfunc import ChatAgent
+from mlflow.types.agent import (
+    ChatAgentMessage,
+    ChatAgentResponse,
+)
+
+from pyspark.sql import SparkSession
+
+
+# ─── Configuration ──────────────────────────────────────────
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+SPARK_REMOTE = os.getenv("SPARK_REMOTE", None)
+SPARK_MASTER = os.getenv("SPARK_MASTER", "local[*]")
+LLM_MODEL = os.getenv("LLM_MODEL", "qwen3-coder:30b")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+# Thresholds for anomaly detection
+THRESHOLDS = {
+    "max_null_rate_pct": 10.0,
+    "max_stale_hours": 24,
+    "max_file_count": 500,
+    "min_row_count": 100,
+    "max_snapshot_count": 20,
+}
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def get_spark():
+    if SPARK_REMOTE:
+        return SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
+    return SparkSession.builder \
+        .master(SPARK_MASTER) \
+        .appName("MLflow-Autopilot-Agent") \
+        .getOrCreate()
+
+
+# ─── Monitoring Tools ───────────────────────────────────────
+def collect_pipeline_metrics() -> dict:
+    """Collect comprehensive metrics across all lakehouse tables."""
+    spark = get_spark()
+    metrics = {"timestamp": datetime.now().isoformat(), "tables": {}, "anomalies": []}
+
+    tables = [
+        "iceberg.bronze.orders",
+        "iceberg.bronze.dim_locations",
+        "iceberg.bronze.dim_brands",
+        "iceberg.bronze.dim_items",
+        "iceberg.bronze.dim_categories",
+    ]
+
+    for table in tables:
+        table_metrics = {"name": table}
+        try:
+            # Row count
+            count = spark.sql(f"SELECT COUNT(*) FROM {table}").collect()[0][0]
+            table_metrics["row_count"] = count
+
+            if count < THRESHOLDS["min_row_count"]:
+                metrics["anomalies"].append({
+                    "type": "low_row_count",
+                    "table": table,
+                    "value": count,
+                    "threshold": THRESHOLDS["min_row_count"],
+                    "severity": "WARNING",
+                })
+
+            # Null rates on key columns
+            df = spark.table(table)
+            for col in df.columns[:5]:
+                null_count = df.filter(f"`{col}` IS NULL").count()
+                null_pct = round(100 * null_count / max(count, 1), 2)
+                table_metrics[f"null_pct_{col}"] = null_pct
+
+                if null_pct > THRESHOLDS["max_null_rate_pct"]:
+                    metrics["anomalies"].append({
+                        "type": "high_null_rate",
+                        "table": table,
+                        "column": col,
+                        "value": null_pct,
+                        "threshold": THRESHOLDS["max_null_rate_pct"],
+                        "severity": "WARNING",
+                    })
+
+            # File count (Iceberg metadata)
+            try:
+                file_count = spark.sql(
+                    f"SELECT COUNT(*) FROM {table}.files"
+                ).collect()[0][0]
+                table_metrics["file_count"] = file_count
+
+                if file_count > THRESHOLDS["max_file_count"]:
+                    metrics["anomalies"].append({
+                        "type": "high_file_count",
+                        "table": table,
+                        "value": file_count,
+                        "threshold": THRESHOLDS["max_file_count"],
+                        "severity": "ACTION_NEEDED",
+                        "recommended_action": "compact",
+                    })
+            except Exception:
+                table_metrics["file_count"] = "unknown"
+
+            # Snapshot count
+            try:
+                snap_count = spark.sql(
+                    f"SELECT COUNT(*) FROM {table}.snapshots"
+                ).collect()[0][0]
+                table_metrics["snapshot_count"] = snap_count
+
+                if snap_count > THRESHOLDS["max_snapshot_count"]:
+                    metrics["anomalies"].append({
+                        "type": "high_snapshot_count",
+                        "table": table,
+                        "value": snap_count,
+                        "threshold": THRESHOLDS["max_snapshot_count"],
+                        "severity": "ACTION_NEEDED",
+                        "recommended_action": "expire_snapshots",
+                    })
+            except Exception:
+                table_metrics["snapshot_count"] = "unknown"
+
+        except Exception as e:
+            table_metrics["error"] = str(e)
+
+        metrics["tables"][table] = table_metrics
+
+    return metrics
+
+
+def execute_maintenance(table_name: str, action: str) -> dict:
+    """Execute maintenance action on a table."""
+    spark = get_spark()
+    result = {"table": table_name, "action": action, "timestamp": datetime.now().isoformat()}
+
+    try:
+        if action == "compact":
+            spark.sql(f"CALL iceberg.system.rewrite_data_files(table => '{table_name}')")
+            result["status"] = "success"
+        elif action == "expire_snapshots":
+            cutoff = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
+            spark.sql(
+                f"CALL iceberg.system.expire_snapshots("
+                f"table => '{table_name}', older_than => TIMESTAMP '{cutoff}', retain_last => 5)"
+            )
+            result["status"] = "success"
+        elif action == "remove_orphans":
+            cutoff = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S")
+            spark.sql(
+                f"CALL iceberg.system.remove_orphan_files("
+                f"table => '{table_name}', older_than => TIMESTAMP '{cutoff}')"
+            )
+            result["status"] = "success"
+        else:
+            result["status"] = "error"
+            result["detail"] = f"Unknown action: {action}"
+    except Exception as e:
+        result["status"] = "error"
+        result["detail"] = str(e)
+
+    return result
+
+
+def check_streaming_health() -> dict:
+    """Check Kafka / streaming pipeline health."""
+    result = {"timestamp": datetime.now().isoformat(), "streaming": {}}
+
+    # Check Kafka connectivity
+    try:
+        import socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(3)
+        kafka_result = sock.connect_ex(("localhost", 9092))
+        sock.close()
+        result["streaming"]["kafka_reachable"] = kafka_result == 0
+    except Exception:
+        result["streaming"]["kafka_reachable"] = False
+
+    # Check Spark streaming queries (if any active)
+    try:
+        spark = get_spark()
+        active_queries = spark.streams.active
+        result["streaming"]["active_queries"] = len(active_queries)
+        for q in active_queries:
+            result["streaming"][q.name or q.id] = {
+                "status": q.status,
+                "recent_progress": str(q.recentProgress[-1]) if q.recentProgress else "none",
+            }
+    except Exception:
+        result["streaming"]["active_queries"] = "unknown"
+
+    return result
+
+
+# ─── Tool Registry ──────────────────────────────────────────
+TOOLS = {
+    "collect_metrics": {
+        "fn": collect_pipeline_metrics,
+        "description": "Collect comprehensive health metrics across all lakehouse tables: row counts, null rates, file counts, snapshot counts, anomalies",
+    },
+    "execute_maintenance": {
+        "fn": execute_maintenance,
+        "description": "Execute maintenance on a table: compact, expire_snapshots, remove_orphans",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "table_name": {"type": "string"},
+                "action": {"type": "string", "enum": ["compact", "expire_snapshots", "remove_orphans"]},
+            },
+            "required": ["table_name", "action"],
+        },
+    },
+    "check_streaming": {
+        "fn": check_streaming_health,
+        "description": "Check streaming pipeline health: Kafka connectivity, active Spark streaming queries",
+    },
+}
+
+TOOL_SCHEMAS = []
+for name, info in TOOLS.items():
+    schema = {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": info["description"],
+            "parameters": info.get("parameters", {"type": "object", "properties": {}}),
+        },
+    }
+    TOOL_SCHEMAS.append(schema)
+
+SYSTEM_PROMPT = """You are the Pipeline Autopilot — an autonomous agent that monitors and
+maintains a data lakehouse. You are responsible for:
+
+1. Collecting pipeline metrics (table health, data quality, file counts)
+2. Detecting anomalies (high null rates, stale data, too many small files)
+3. Taking corrective action (compaction, snapshot expiry, orphan cleanup)
+4. Checking streaming health (Kafka, active queries)
+
+You run in a monitoring loop. Each cycle:
+  1. Collect metrics from all tables
+  2. Analyze for anomalies
+  3. If anomalies found: decide and execute maintenance actions
+  4. Report findings
+
+Be proactive. If you see high file counts, compact. If you see too many snapshots, expire.
+If streaming is down, report it. Be concise and action-oriented."""
+
+
+# ─── Agent ──────────────────────────────────────────────────
+class PipelineAutopilotAgent(ChatAgent):
+    def __init__(self):
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            import openai
+            self._client = openai.OpenAI(base_url=OLLAMA_BASE_URL, api_key="ollama")
+        return self._client
+
+    def _call_llm(self, messages, tools=None):
+        """Call the LLM via OpenAI-compatible API (Ollama)."""
+        kwargs = {
+            "model": LLM_MODEL, "max_tokens": 4096,
+            "messages": [{"role": "system", "content": SYSTEM_PROMPT}] + messages,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        return self.client.chat.completions.create(**kwargs)
+
+    def _extract_response(self, response):
+        """Extract text and tool calls from OpenAI-compatible response."""
+        msg = response.choices[0].message
+        tool_calls = []
+        if msg.tool_calls:
+            for tc in msg.tool_calls:
+                tool_calls.append({"id": tc.id, "name": tc.function.name,
+                                   "arguments": json.loads(tc.function.arguments)})
+        return msg.content or "", tool_calls
+
+    @mlflow.trace
+    def predict(self, messages, context=None, custom_inputs=None):
+        conv = [{"role": m.role, "content": m.content} for m in messages]
+        all_text = []
+
+        for _ in range(12):  # More iterations for autonomous actions
+            response = self._call_llm(conv, tools=TOOL_SCHEMAS)
+            text, tool_calls = self._extract_response(response)
+
+            if text:
+                all_text.append(text)
+
+            if not tool_calls:
+                break
+
+            # Execute tools (OpenAI-compatible format)
+            conv.append({"role": "assistant", "content": text,
+                         "tool_calls": [{"id": tc["id"], "type": "function",
+                                         "function": {"name": tc["name"],
+                                                      "arguments": json.dumps(tc["arguments"])}}
+                                        for tc in tool_calls]})
+            for tc in tool_calls:
+                tool_fn = TOOLS[tc["name"]]["fn"]
+                with mlflow.start_span(name=f"autopilot:{tc['name']}") as span:
+                    span.set_inputs(tc["arguments"])
+                    result = tool_fn(**tc["arguments"])
+                    span.set_outputs(result)
+                conv.append({"role": "tool", "tool_call_id": tc["id"],
+                             "content": json.dumps(result, default=str)})
+
+        return ChatAgentResponse(
+            messages=[ChatAgentMessage(role="assistant", content="\n".join(all_text), id=str(uuid.uuid4()))]
+        )
+
+
+# ─── Monitoring Loop ────────────────────────────────────────
+def run_monitoring_loop(agent, interval_seconds=60, max_cycles=5, tracking_available=False):
+    """Run the autopilot in a monitoring loop."""
+    section("Autopilot Monitoring Loop")
+    print(f"  Interval: {interval_seconds}s | Max cycles: {max_cycles}")
+
+    for cycle in range(1, max_cycles + 1):
+        print(f"\n{'═' * 60}")
+        print(f"  Monitoring Cycle {cycle}/{max_cycles} — {datetime.now().strftime('%H:%M:%S')}")
+        print(f"{'═' * 60}")
+
+        try:
+            mlflow.end_run()
+            run_ctx = mlflow.start_run(run_name=f"autopilot_cycle_{cycle}") if tracking_available else None
+            if run_ctx:
+                run_ctx.__enter__()
+            response = agent.predict(messages=[
+                ChatAgentMessage(
+                    role="user",
+                    content="Run a full health check. Collect metrics from all tables, "
+                            "check streaming health, and take any needed maintenance actions. "
+                            "Report your findings and any actions taken."
+                )
+            ])
+            print(f"\n  Autopilot Report:")
+            for msg in response.messages:
+                for line in msg.content.split("\n"):
+                    print(f"  {line}")
+            if run_ctx:
+                run_ctx.__exit__(None, None, None)
+        except Exception as e:
+            print(f"  Cycle {cycle} error: {e}")
+
+        if cycle < max_cycles:
+            print(f"\n  Next cycle in {interval_seconds}s...")
+            time.sleep(interval_seconds)
+
+
+# ─── Demo ───────────────────────────────────────────────────
+def run_demo():
+    section("MLflow Pipeline Autopilot Agent")
+
+    tracking_available = False
+    try:
+        mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+        mlflow.set_experiment("overarchitected-autopilot")
+        tracking_available = True
+    except Exception:
+        print("  MLflow tracking server not available — running without tracking.")
+
+    if tracking_available:
+        try:
+            mlflow.openai.autolog()
+        except Exception:
+            pass
+
+    agent = PipelineAutopilotAgent()
+
+    print(f"\n  LLM Provider: {LLM_PROVIDER}")
+    print(f"  LLM Model: {LLM_MODEL}")
+
+    # Check if monitoring mode
+    if "--monitor" in sys.argv:
+        interval = 60
+        for i, arg in enumerate(sys.argv):
+            if arg == "--interval" and i + 1 < len(sys.argv):
+                interval = int(sys.argv[i + 1])
+        run_monitoring_loop(agent, interval_seconds=interval, max_cycles=10, tracking_available=tracking_available)
+    else:
+        # Single-shot demo
+        demo_queries = [
+            "Run a full health check on all lakehouse tables. Report any issues.",
+            "Check streaming health and tell me if Kafka is accessible.",
+            "Analyze the anomalies you found and execute any recommended maintenance actions.",
+        ]
+
+        for i, query in enumerate(demo_queries, 1):
+            print(f"\n{'═' * 60}")
+            print(f"  Autopilot Task {i}: {query}")
+            print(f"{'═' * 60}")
+
+            try:
+                mlflow.end_run()
+            run_ctx = mlflow.start_run(run_name=f"autopilot_demo_{i}") if tracking_available else None
+                if run_ctx:
+                    run_ctx.__enter__()
+                response = agent.predict(
+                    messages=[ChatAgentMessage(role="user", content=query)]
+                )
+                print(f"\n  Autopilot:")
+                for msg in response.messages:
+                    for line in msg.content.split("\n"):
+                        print(f"  {line}")
+                if run_ctx:
+                    run_ctx.__exit__(None, None, None)
+            except Exception as e:
+                print(f"  Error: {e}")
+                import traceback; traceback.print_exc()
+
+    if tracking_available:
+        section("Logging Autopilot to MLflow")
+        try:
+            with mlflow.start_run(run_name="autopilot_registration"):
+                mlflow.pyfunc.log_model(
+                    artifact_path="autopilot_agent",
+                    python_model=agent,
+                    registered_model_name="pipeline-autopilot",
+                )
+                print("  Autopilot logged as 'pipeline-autopilot'")
+        except Exception as e:
+            print(f"  Could not log model: {e}")
+
+
+def main():
+    print("\n" + "=" * 60)
+    print("  PIPELINE AUTOPILOT")
+    print("  Autonomous lakehouse management. The lazy dream.")
+    print("=" * 60)
+
+    run_demo()
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/mlflow-agents/autopilot.py
+++ b/scripts/demos/mlflow-agents/autopilot.py
@@ -403,7 +403,7 @@ def run_demo():
     tracking_available = False
     try:
         mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
-        mlflow.set_experiment("overarchitected-autopilot")
+        mlflow.set_experiment("lakehouse-autopilot")
         tracking_available = True
     except Exception:
         print("  MLflow tracking server not available — running without tracking.")
@@ -441,7 +441,7 @@ def run_demo():
 
             try:
                 mlflow.end_run()
-            run_ctx = mlflow.start_run(run_name=f"autopilot_demo_{i}") if tracking_available else None
+                run_ctx = mlflow.start_run(run_name=f"autopilot_demo_{i}") if tracking_available else None
                 if run_ctx:
                     run_ctx.__enter__()
                 response = agent.predict(

--- a/scripts/demos/mlflow-agents/guardian.py
+++ b/scripts/demos/mlflow-agents/guardian.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""
+MLflow Pipeline Guardian Agent
+======================================================
+
+"We're lazy. Can AI manage the lakehouse for us?"
+
+Option A: Pipeline Guardian — an agent that inspects Iceberg table health,
+checks data quality, and recommends/triggers maintenance actions.
+
+Architecture:
+  MLflow Agent Server (FastAPI) → ResponsesAgent → Tools:
+    - inspect_table: check row counts, snapshots, file counts
+    - check_quality: null rates, freshness, duplicate detection
+    - run_maintenance: trigger compaction, snapshot expiry
+    - query_table: run arbitrary SQL for investigation
+
+  All LLM calls routed through MLflow AI Gateway.
+  Every action traced via MLflow Tracing (OpenTelemetry).
+  Agent registered in Unity Catalog model registry.
+
+Run:
+    # Start MLflow tracking server first:
+    docker compose -f docker-compose-mlflow.yml up -d
+
+    # Run the agent:
+    python scripts/demos/mlflow-agents/guardian.py
+
+    # Or serve it:
+    mlflow models serve -m runs:/<run_id>/guardian_agent -p 5001
+
+Prerequisites:
+    pip install mlflow>=3.1 openai pyspark
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+    # Uses Ollama (local OSS models) via OpenAI-compatible API. No API keys needed.
+"""
+
+import os
+import json
+import uuid
+from datetime import datetime, timedelta
+
+# MLflow imports
+import mlflow
+from mlflow.pyfunc import ChatAgent
+from mlflow.types.agent import (
+    ChatAgentMessage,
+    ChatAgentResponse,
+    ChatContext,
+)
+
+# PySpark thin client
+from pyspark.sql import SparkSession
+
+
+# ─── Configuration ──────────────────────────────────────────
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+SPARK_REMOTE = os.getenv("SPARK_REMOTE", None)  # sc://host:15002 for Connect
+SPARK_MASTER = os.getenv("SPARK_MASTER", "local[*]")
+LLM_MODEL = os.getenv("LLM_MODEL", "qwen3-coder:30b")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")  # "openai" for Ollama-compatible API
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+# ─── Spark Connection ──────────────────────────────────────
+def get_spark():
+    """Get Spark session — prefer Connect if available."""
+    if SPARK_REMOTE:
+        return SparkSession.builder.remote(SPARK_REMOTE).getOrCreate()
+    return SparkSession.builder \
+        .master(SPARK_MASTER) \
+        .appName("MLflow-Guardian-Agent") \
+        .getOrCreate()
+
+
+# ─── Tool Functions ─────────────────────────────────────────
+def inspect_table(table_name: str) -> dict:
+    """Inspect an Iceberg table: row count, snapshots, partition info."""
+    spark = get_spark()
+    result = {"table": table_name}
+
+    try:
+        count = spark.sql(f"SELECT COUNT(*) FROM {table_name}").collect()[0][0]
+        result["row_count"] = count
+    except Exception as e:
+        result["error"] = f"Cannot read table: {e}"
+        return result
+
+    # Snapshot history
+    try:
+        snapshots = spark.sql(
+            f"SELECT * FROM {table_name}.snapshots ORDER BY committed_at DESC"
+        ).limit(10).collect()
+        result["snapshot_count"] = len(snapshots)
+        if snapshots:
+            result["latest_snapshot"] = str(snapshots[0]["committed_at"])
+            result["oldest_snapshot"] = str(snapshots[-1]["committed_at"])
+    except Exception:
+        result["snapshot_count"] = "unknown"
+
+    # File metadata
+    try:
+        files = spark.sql(
+            f"SELECT COUNT(*) as file_count, "
+            f"SUM(file_size_in_bytes) as total_bytes "
+            f"FROM {table_name}.files"
+        ).collect()[0]
+        result["file_count"] = files["file_count"]
+        result["total_size_mb"] = round(files["total_bytes"] / (1024 * 1024), 2) if files["total_bytes"] else 0
+    except Exception:
+        result["file_count"] = "unknown"
+
+    return result
+
+
+def check_quality(table_name: str) -> dict:
+    """Check data quality: null rates, freshness, basic stats."""
+    spark = get_spark()
+    result = {"table": table_name, "checks": []}
+
+    try:
+        df = spark.table(table_name)
+        total = df.count()
+        result["total_rows"] = total
+
+        if total == 0:
+            result["checks"].append({"check": "empty_table", "status": "FAIL", "detail": "Table has 0 rows"})
+            return result
+
+        # Null checks on key columns
+        for col_name in df.columns[:10]:  # Check first 10 columns
+            null_count = df.filter(f"`{col_name}` IS NULL").count()
+            null_pct = round(100 * null_count / total, 2)
+            status = "WARN" if null_pct > 5 else "PASS"
+            if null_pct > 20:
+                status = "FAIL"
+            result["checks"].append({
+                "check": f"null_rate_{col_name}",
+                "status": status,
+                "null_count": null_count,
+                "null_pct": null_pct,
+            })
+
+        # Freshness check (look for timestamp columns)
+        ts_cols = [c.name for c in df.schema if "timestamp" in c.dataType.simpleString().lower()
+                   or "ts" in c.name.lower()]
+        if ts_cols:
+            ts_col = ts_cols[0]
+            try:
+                latest = spark.sql(
+                    f"SELECT MAX(`{ts_col}`) FROM {table_name}"
+                ).collect()[0][0]
+                if latest:
+                    freshness_hours = (datetime.now() - latest).total_seconds() / 3600
+                    status = "PASS" if freshness_hours < 24 else "WARN"
+                    if freshness_hours > 72:
+                        status = "FAIL"
+                    result["checks"].append({
+                        "check": "data_freshness",
+                        "status": status,
+                        "latest_timestamp": str(latest),
+                        "hours_since_update": round(freshness_hours, 1),
+                    })
+            except Exception:
+                pass
+
+        # Duplicate check on first column (likely ID)
+        id_col = df.columns[0]
+        distinct_count = df.select(id_col).distinct().count()
+        dup_count = total - distinct_count
+        if dup_count > 0:
+            result["checks"].append({
+                "check": f"duplicates_{id_col}",
+                "status": "WARN",
+                "duplicate_count": dup_count,
+                "duplicate_pct": round(100 * dup_count / total, 2),
+            })
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def run_maintenance(table_name: str, action: str) -> dict:
+    """Run Iceberg maintenance: compact, expire_snapshots, remove_orphans."""
+    spark = get_spark()
+    result = {"table": table_name, "action": action}
+
+    try:
+        if action == "compact" or action == "rewrite_data_files":
+            spark.sql(f"CALL iceberg.system.rewrite_data_files(table => '{table_name}')")
+            result["status"] = "completed"
+            result["detail"] = "Data files rewritten (compacted)"
+
+        elif action == "expire_snapshots":
+            cutoff = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
+            spark.sql(
+                f"CALL iceberg.system.expire_snapshots("
+                f"table => '{table_name}', "
+                f"older_than => TIMESTAMP '{cutoff}', "
+                f"retain_last => 5)"
+            )
+            result["status"] = "completed"
+            result["detail"] = f"Snapshots older than {cutoff} expired (keeping last 5)"
+
+        elif action == "remove_orphans":
+            cutoff = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S")
+            spark.sql(
+                f"CALL iceberg.system.remove_orphan_files("
+                f"table => '{table_name}', "
+                f"older_than => TIMESTAMP '{cutoff}')"
+            )
+            result["status"] = "completed"
+            result["detail"] = f"Orphan files older than {cutoff} removed"
+
+        else:
+            result["status"] = "error"
+            result["detail"] = f"Unknown action: {action}. Use: compact, expire_snapshots, remove_orphans"
+
+    except Exception as e:
+        result["status"] = "error"
+        result["detail"] = str(e)
+
+    return result
+
+
+def query_table(sql: str) -> dict:
+    """Run arbitrary SQL against the lakehouse. Returns up to 20 rows."""
+    spark = get_spark()
+    result = {"sql": sql}
+
+    try:
+        df = spark.sql(sql)
+        rows = df.limit(20).collect()
+        result["columns"] = df.columns
+        result["row_count"] = len(rows)
+        result["data"] = [row.asDict() for row in rows]
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+# ─── Tool Registry ──────────────────────────────────────────
+TOOLS = {
+    "inspect_table": {
+        "fn": inspect_table,
+        "description": "Inspect an Iceberg table: row count, snapshots, file counts, total size",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "table_name": {"type": "string", "description": "Fully qualified table name (e.g., iceberg.bronze.orders)"}
+            },
+            "required": ["table_name"]
+        }
+    },
+    "check_quality": {
+        "fn": check_quality,
+        "description": "Check data quality: null rates, freshness, duplicates",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "table_name": {"type": "string", "description": "Fully qualified table name"}
+            },
+            "required": ["table_name"]
+        }
+    },
+    "run_maintenance": {
+        "fn": run_maintenance,
+        "description": "Run Iceberg maintenance: compact (rewrite_data_files), expire_snapshots, remove_orphans",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "table_name": {"type": "string", "description": "Fully qualified table name"},
+                "action": {"type": "string", "enum": ["compact", "expire_snapshots", "remove_orphans"]}
+            },
+            "required": ["table_name", "action"]
+        }
+    },
+    "query_table": {
+        "fn": query_table,
+        "description": "Run SQL against the lakehouse. Returns up to 20 rows. Use for investigation.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "sql": {"type": "string", "description": "SQL query to execute"}
+            },
+            "required": ["sql"]
+        }
+    },
+}
+
+TOOL_SCHEMAS = [
+    {"type": "function", "function": {"name": name, "description": info["description"], "parameters": info["parameters"]}}
+    for name, info in TOOLS.items()
+]
+
+SYSTEM_PROMPT = """You are the Pipeline Guardian — an AI agent that monitors and maintains
+a data lakehouse built on Apache Spark + Iceberg + PostgreSQL + SeaweedFS.
+
+Your responsibilities:
+1. Inspect table health (row counts, snapshots, file counts)
+2. Check data quality (null rates, freshness, duplicates)
+3. Recommend and execute maintenance (compaction, snapshot expiry, orphan cleanup)
+4. Answer questions about the data by running SQL queries
+
+Available tables:
+- iceberg.bronze.orders (raw order events)
+- iceberg.bronze.dim_locations (delivery locations)
+- iceberg.bronze.dim_brands (restaurant brands)
+- iceberg.bronze.dim_items (menu items)
+- iceberg.bronze.dim_categories (item categories)
+- iceberg.silver.orders_enriched (if pipeline has run)
+- iceberg.gold.hourly_metrics (if pipeline has run)
+
+When asked to check health, inspect all bronze tables and report findings.
+When you find issues, recommend specific maintenance actions.
+Be concise and technical. This is for a live demo."""
+
+
+# ─── Agent Implementation ──────────────────────────────────
+class PipelineGuardianAgent(ChatAgent):
+    """MLflow ChatAgent that guards the lakehouse pipeline."""
+
+    def __init__(self):
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            import openai
+            self._client = openai.OpenAI(base_url=OLLAMA_BASE_URL, api_key="ollama")
+        return self._client
+
+    def _call_llm(self, messages, tools=None):
+        """Call the LLM via OpenAI-compatible API (Ollama)."""
+        kwargs = {
+            "model": LLM_MODEL,
+            "messages": [{"role": "system", "content": SYSTEM_PROMPT}] + messages,
+            "max_tokens": 4096,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        return self.client.chat.completions.create(**kwargs)
+
+    def _extract_response(self, response):
+        """Extract text and tool calls from OpenAI-compatible response."""
+        msg = response.choices[0].message
+        text = msg.content or ""
+        tool_calls = []
+        if msg.tool_calls:
+            for tc in msg.tool_calls:
+                tool_calls.append({
+                    "id": tc.id,
+                    "name": tc.function.name,
+                    "arguments": json.loads(tc.function.arguments),
+                })
+        return text, tool_calls, response.choices[0].finish_reason
+
+    @mlflow.trace
+    def predict(self, messages, context=None, custom_inputs=None):
+        """Run the agent with tool-calling loop."""
+        # Convert ChatAgentMessage to dicts
+        conv = [{"role": m.role, "content": m.content} for m in messages]
+
+        max_iterations = 10
+        all_text = []
+
+        for _ in range(max_iterations):
+            response = self._call_llm(conv, tools=TOOL_SCHEMAS)
+            text, tool_calls, stop_reason = self._extract_response(response)
+
+            if text:
+                all_text.append(text)
+
+            if not tool_calls:
+                break
+
+            # Execute tool calls (OpenAI-compatible format)
+            conv.append({
+                "role": "assistant",
+                "content": text,
+                "tool_calls": [
+                    {"id": tc["id"], "type": "function",
+                     "function": {"name": tc["name"], "arguments": json.dumps(tc["arguments"])}}
+                    for tc in tool_calls
+                ],
+            })
+            for tc in tool_calls:
+                tool_fn = TOOLS[tc["name"]]["fn"]
+                with mlflow.start_span(name=f"tool:{tc['name']}") as span:
+                    span.set_inputs(tc["arguments"])
+                    result = tool_fn(**tc["arguments"])
+                    span.set_outputs(result)
+
+                conv.append({
+                    "role": "tool",
+                    "tool_call_id": tc["id"],
+                    "content": json.dumps(result, default=str),
+                })
+
+        final_text = "\n".join(all_text) if all_text else "No response generated."
+        return ChatAgentResponse(
+            messages=[ChatAgentMessage(role="assistant", content=final_text, id=str(uuid.uuid4()))]
+        )
+
+
+# ─── Demo Runner ────────────────────────────────────────────
+def run_demo():
+    """Run the Pipeline Guardian agent interactively."""
+    section("MLflow Pipeline Guardian Agent")
+
+    # Set up MLflow tracking (optional — works without tracking server)
+    tracking_available = False
+    try:
+        mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+        mlflow.set_experiment("overarchitected-guardian")
+        tracking_available = True
+    except Exception:
+        print("  MLflow tracking server not available — running without tracking.")
+
+    if tracking_available:
+        try:
+            mlflow.openai.autolog()
+        except Exception:
+            pass
+
+    agent = PipelineGuardianAgent()
+
+    # Demo queries
+    demo_queries = [
+        "Check the health of all bronze tables. Give me a summary.",
+        "What's the data quality like in iceberg.bronze.orders? Any issues?",
+        "Run compaction on iceberg.bronze.orders and expire old snapshots.",
+    ]
+
+    print(f"\n  LLM Provider: {LLM_PROVIDER}")
+    print(f"  LLM Model: {LLM_MODEL}")
+    print(f"  MLflow Tracking: {MLFLOW_TRACKING_URI}")
+    print(f"  Spark: {SPARK_REMOTE or SPARK_MASTER}")
+
+    for i, query in enumerate(demo_queries, 1):
+        print(f"\n{'═' * 60}")
+        print(f"  Demo Query {i}: {query}")
+        print(f"{'═' * 60}")
+
+        try:
+            mlflow.end_run()
+            run_ctx = mlflow.start_run(run_name=f"guardian_demo_{i}") if tracking_available else None
+            if run_ctx:
+                run_ctx.__enter__()
+            response = agent.predict(
+                messages=[ChatAgentMessage(role="user", content=query)]
+            )
+            print(f"\n  Agent Response:")
+            print(f"  {'-' * 50}")
+            for msg in response.messages:
+                print(f"  {msg.content}")
+            if run_ctx:
+                run_ctx.__exit__(None, None, None)
+        except Exception as e:
+            print(f"  Error: {e}")
+            import traceback; traceback.print_exc()
+
+    # Log the agent model
+    if tracking_available:
+        section("Logging Agent to MLflow")
+        try:
+            with mlflow.start_run(run_name="guardian_agent_registration"):
+                mlflow.pyfunc.log_model(
+                    artifact_path="guardian_agent",
+                    python_model=agent,
+                    registered_model_name="pipeline-guardian",
+                )
+                print("  Agent logged to MLflow model registry as 'pipeline-guardian'")
+        except Exception as e:
+            print(f"  Could not log model: {e}")
+
+
+def main():
+    print("\n" + "=" * 60)
+    print("  PIPELINE GUARDIAN AGENT")
+    print("  AI manages the lakehouse. We watch.")
+    print("=" * 60)
+
+    run_demo()
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/mlflow-agents/guardian.py
+++ b/scripts/demos/mlflow-agents/guardian.py
@@ -423,7 +423,7 @@ def run_demo():
     tracking_available = False
     try:
         mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
-        mlflow.set_experiment("overarchitected-guardian")
+        mlflow.set_experiment("lakehouse-guardian")
         tracking_available = True
     except Exception:
         print("  MLflow tracking server not available — running without tracking.")

--- a/scripts/demos/showcase/README.md
+++ b/scripts/demos/showcase/README.md
@@ -1,0 +1,49 @@
+# Stack Showcase Demos
+
+Focused scripts that each exercise one part of the stack. Pick one based on
+what you want to see; they do not need to run in order.
+
+## Running
+
+All scripts assume the stack is up:
+
+```bash
+./lakehouse start all
+./lakehouse testdata generate --days 7
+./lakehouse testdata load
+```
+
+Python demos run via `spark-submit` inside the Spark 4.1 container:
+
+```bash
+docker exec spark-master-41 /opt/spark/bin/spark-submit \
+    /scripts/demos/showcase/<demo>.py
+```
+
+The shell demo runs from the host.
+
+## What's here
+
+| Demo | Shows | Needs |
+|------|-------|-------|
+| `otf_portability.py` | Reading Iceberg/Parquet from outside any managed platform | Iceberg catalog |
+| `iceberg_variant.py` | Spark 4.1 VARIANT type over semi-structured Iceberg rows | Spark 4.1 + Iceberg |
+| `unity_catalog_setup.py` | End-to-end UC OSS bootstrap and multi-client access | Unity Catalog |
+| `spark_cluster_diagnostic.py` | Cluster introspection, config tour, common pitfalls | Spark 4.1 |
+| `spark41_feature_tour.py` | VARIANT + recursive CTE + collation + SDP + Iceberg in one pass | Spark 4.1 |
+| `streaming_udtf.py` | Python UDTFs on a streaming DataFrame | Kafka + Spark 4.1 |
+| `sdp_showcase.py` | Imperative vs declarative pipeline side-by-side | Spark 4.1 |
+| `sdp_demo.py` | Clean medallion pipeline driven by `sdp-pipeline.yml` | Spark 4.1 |
+| `realtime_mode.py` | Structured Streaming Real-Time Mode vs micro-batch | Kafka + Spark 4.1 |
+| `airflow_sdp.py` | Airflow DAG patterns for running SDP on a schedule | Airflow + Spark |
+| `spark_connect.py` | Running jobs against a remote Spark driver via Spark Connect | Spark Connect |
+| `spark_on_k8s.sh` | Submitting a Spark job to a Kubernetes cluster | `kubectl` + K8s |
+
+## sdp-pipeline.yml
+
+Config for `sdp_demo.py`. Run with:
+
+```bash
+docker exec spark-master-41 /opt/spark/bin/spark-pipelines run \
+    --spec /scripts/demos/showcase/sdp-pipeline.yml
+```

--- a/scripts/demos/showcase/airflow_sdp.py
+++ b/scripts/demos/showcase/airflow_sdp.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Airflow + SDP — Enterprise Orchestration
+=================================================================
+
+"How do we schedule this?" Airflow orchestrates, SDP defines pipelines.
+This script demonstrates the operator landscape and how to wire SDP into Airflow.
+
+NOTE: This is a reference/demo script that shows Airflow DAG patterns.
+The actual DAG file lives at dags/sdp_pipeline.py.
+
+This script can also be run standalone to test the SparkSubmit + SDP
+commands that Airflow would execute.
+
+Run (standalone test):
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/airflow_sdp.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse start airflow
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def act5a_operator_landscape():
+    """Step 1: The Airflow Spark operator landscape."""
+    section("STEP 1: Airflow Spark Operators (Which One?)")
+
+    print("""
+  apache-airflow-providers-apache-spark v5.5.1 (March 2026)
+
+  ┌─────────────────────────┬───────────────────────────────────────────┐
+  │ Operator                │ Use Case                                  │
+  ├─────────────────────────┼───────────────────────────────────────────┤
+  │ SparkSubmitOperator     │ Submit any Spark app (scripts, JARs)      │
+  │                         │ Wraps spark-submit CLI                    │
+  │                         │ Works with all cluster managers            │
+  │                         │ THIS IS HOW YOU RUN SDP                   │
+  ├─────────────────────────┼───────────────────────────────────────────┤
+  │ SparkSqlOperator        │ Run Spark SQL queries directly            │
+  │                         │ Wraps spark-sql CLI                       │
+  │                         │ Good for DDL, simple transforms           │
+  ├─────────────────────────┼───────────────────────────────────────────┤
+  │ PysparkOperator (NEW)   │ Run PySpark code inline in the DAG        │
+  │ (v5.5.0, Jan 2026)     │ No separate .py file needed               │
+  │                         │ Good for small transforms, prototyping     │
+  ├─────────────────────────┼───────────────────────────────────────────┤
+  │ SparkJDBCOperator       │ Spark ↔ JDBC data transfers               │
+  │                         │ Niche — use SparkSubmit for most cases     │
+  ├─────────────────────────┼───────────────────────────────────────────┤
+  │ SparkKubernetesOperator │ Spark on K8s (separate cncf-k8s provider) │
+  │                         │ Direct K8s pod management                  │
+  └─────────────────────────┴───────────────────────────────────────────┘
+
+  New DeclarativePipelinesOperator! Just merged in ;).
+  SDP runs via SparkSubmitOperator wrapping `spark-pipelines run`.
+  This is actually fine — SDP is built on top of spark-submit.
+    """)
+
+
+def act5a_sdp_in_airflow():
+    """Step 2: How to wire SDP into an Airflow DAG."""
+    section("STEP 2: SDP in Airflow (The DAG)")
+
+    print("""
+  A user asks: "How does Airflow know about my SDP pipeline?"
+
+  It doesn't. Airflow orchestrates WHEN. SDP handles WHAT and HOW.
+
+  ┌──────────────────────────────────────────────────────────────┐
+  │  Airflow DAG: lakehouse_sdp_pipeline                         │
+  │                                                              │
+  │  [preflight_check] → [run_sdp_pipeline] → [verify_tables]   │
+  │                                                              │
+  │  run_sdp_pipeline = SparkSubmitOperator(                     │
+  │      application="spark-pipelines",                          │
+  │      application_args=["run",                                │
+  │                        "--spec", "/scripts/pipelines/spark-pipeline.yml"],│
+  │      conn_id="spark_41",                                     │
+  │      conf={                                                  │
+  │          "spark.master": "spark://spark-master-41:7078",     │
+  │          "spark.sql.catalog.iceberg": "org.apache.iceberg...",│
+  │      },                                                      │
+  │  )                                                           │
+  └──────────────────────────────────────────────────────────────┘
+
+  Separation of concerns:
+    - Airflow: schedule, retry, alert, dependency between DAGs
+    - SDP: dependency between TABLES, execution order, writes
+    - They don't compete — they complement
+    """)
+
+
+def act5a_pyspark_operator():
+    """Step 3: The new PysparkOperator (v5.5.0)."""
+    section("STEP 3: PysparkOperator (New in v5.5.0)")
+
+    print("""
+  A user asks: "Can I just write PySpark inline in the DAG?"
+
+  Yes. The PysparkOperator (January 2026) lets you do this:
+
+  @task.pyspark(conn_id="spark_41")
+  def check_table_freshness(spark: SparkSession):
+      latest = spark.sql('''
+          SELECT MAX(event_timestamp)
+          FROM iceberg.bronze.orders
+      ''').collect()[0][0]
+      if latest < datetime.now() - timedelta(hours=2):
+          raise AirflowException("Data is stale!")
+      return str(latest)
+
+  When to use which:
+    - PysparkOperator: quick checks, small transforms, prototyping
+    - SparkSubmitOperator: production pipelines, SDP, heavy workloads
+    - SparkSqlOperator: DDL, simple SQL queries
+    """)
+
+
+def act5a_existing_dags():
+    """Step 4: What DAGs we already have."""
+    section("STEP 4: Existing Airflow DAGs")
+
+    print("""
+  Our lakehouse already has two production DAGs:
+
+  1. lakehouse_medallion_pipeline (dags/lakehouse_medallion_pipeline.py)
+     - Schedule: @daily
+     - Tasks: check_kafka → choose_spark_version → run_pipeline → verify_tables
+     - Supports both Spark 4.0 and 4.1 (branching)
+
+  2. iceberg_maintenance (dags/iceberg_maintenance.py)
+     - Schedule: daily at 3 AM
+     - Tasks: expire_snapshots → remove_orphan_files → rewrite_data_files
+     - Tables: bronze.orders, silver.orders_clean, gold.daily_summary
+
+  3. lakehouse_sdp_pipeline (dags/sdp_pipeline.py) ← NEW
+     - Schedule: @daily
+     - Tasks: preflight → run_sdp → verify → iceberg_maintenance
+     - Uses SparkSubmitOperator to run `spark-pipelines`
+
+  Airflow UI: http://localhost:8085 (admin/admin)
+    """)
+
+
+def act5a_standalone_test(spark):
+    """Step 5: Test the SDP command that Airflow would run."""
+    section("STEP 5: Testing SDP Command (What Airflow Executes)")
+
+    print("""
+  The command Airflow runs under the hood:
+
+    spark-pipelines run \\
+        --spec /scripts/pipelines/spark-pipeline.yml \\
+        --master spark://spark-master-41:7078
+
+  Or equivalently via spark-submit:
+
+    spark-submit \\
+        --master spark://spark-master-41:7078 \\
+        --class org.apache.spark.sql.connect.pipelines.PipelinesMain \\
+        --conf spark.pipelines.spec=/scripts/pipelines/spark-pipeline.yml \\
+        /path/to/spark-pipelines.jar
+
+  Let's verify the pipeline spec exists and is valid:
+    """)
+
+    # Check if pipeline spec exists
+    try:
+        import os
+        spec_path = "/scripts/pipelines/spark-pipeline.yml"
+        if os.path.exists(spec_path):
+            with open(spec_path) as fh:
+                print(f"  Pipeline spec ({spec_path}):")
+                print(f"  {'─' * 40}")
+                for line in fh:
+                    print(f"    {line.rstrip()}")
+                print(f"  {'─' * 40}")
+        else:
+            print(f"  Pipeline spec not found at {spec_path}")
+    except Exception as e:
+        print(f"  Could not read pipeline spec: {e}")
+
+    # Quick sanity check: can we read the bronze tables?
+    print("\n  Verifying bronze tables are accessible:")
+    for table in ["iceberg.bronze.orders", "iceberg.bronze.dim_locations"]:
+        try:
+            count = spark.sql(f"SELECT COUNT(*) FROM {table}").collect()[0][0]
+            print(f"    {table}: {count:,} rows")
+        except Exception:
+            print(f"    {table}: not found")
+
+
+def main():
+    spark = SparkSession.builder \
+        .appName("lakehouse-demo") \
+        .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("  ENTERPRISE ORCHESTRATION")
+    print("  Airflow schedules. SDP defines. They don't compete.")
+    print("=" * 60)
+    print(f"  Spark version: {spark.version}")
+
+    act5a_operator_landscape()
+    act5a_sdp_in_airflow()
+    act5a_pyspark_operator()
+    act5a_existing_dags()
+    act5a_standalone_test(spark)
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("  Next: Spark Connect + Kubernetes scaling.")
+    print("=" * 60 + "\n")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/iceberg_variant.py
+++ b/scripts/demos/showcase/iceberg_variant.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+VARIANT Type + Iceberg
+==============================================
+
+Demonstrates Spark 4.1 VARIANT type for semi-structured order bodies.
+- parse_json() converts JSON string to VARIANT
+- variant_get() extracts fields with JSONPath
+- Writes to Iceberg with flexible schema
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/iceberg_variant.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+
+def main():
+    spark = SparkSession.builder.appName("lakehouse-demo").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("VARIANT Type + Iceberg")
+    print("=" * 60)
+    print(f"Spark version: {spark.version}")
+
+    # Read orders (use parquet if available, else create sample)
+    try:
+        df = spark.read.parquet("/data/events/orders_90d.parquet").limit(2000)
+        print(f"Loaded {df.count()} rows from /data/events/orders_90d.parquet")
+    except Exception:
+        # Fallback: create sample data
+        from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+        schema = StructType([
+            StructField("event_id", StringType()),
+            StructField("event_type", StringType()),
+            StructField("ts", StringType()),
+            StructField("order_id", StringType()),
+            StructField("location_id", IntegerType()),
+            StructField("sequence", IntegerType()),
+            StructField("body", StringType()),
+        ])
+        sample = [
+            ("e1", "order_created", "2024-01-15T12:00:00", "ORD001", 1, 0,
+             '{"brand_id":1,"total":25.99,"items":[{"name":"Burger","price":12.99}]}'),
+            ("e2", "delivered", "2024-01-15T12:45:00", "ORD001", 1, 7,
+             '{"delivery_lat":37.77,"delivery_lon":-122.41,"total_mins":45.0}'),
+        ]
+        df = spark.createDataFrame(sample * 500, schema)
+        print("Using sample data (parquet not found)")
+
+    # Add timestamp
+    df = df.withColumn("event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " ")))
+
+    # VARIANT: parse_json (Spark 4.1) - fallback to from_json if unavailable
+    # Use try_parse_json to handle malformed JSON (trailing commas etc.) gracefully
+    try:
+        df_variant = df.withColumn("body_variant", f.try_parse_json("body"))
+        print("\n[VARIANT] Using try_parse_json() -> VARIANT type")
+    except AttributeError:
+        # Fallback: use from_json with generic schema
+        df_variant = df.withColumn("body_variant", f.from_json("body", "map<string,string>"))
+        print("\n[FALLBACK] Using from_json (VARIANT not available in this build)")
+
+    # Extract fields - use try_variant_get for safe extraction
+    try:
+        df_extracted = df_variant.withColumn(
+            "brand_id", f.expr("try_variant_get(body_variant, '$.brand_id', 'int')")
+        ).withColumn(
+            "total", f.expr("try_variant_get(body_variant, '$.total', 'double')")
+        ).withColumn(
+            "driver_id", f.expr("try_variant_get(body_variant, '$.driver_id', 'string')")
+        )
+        print("[VARIANT] Extracted brand_id, total, driver_id via try_variant_get()")
+    except Exception:
+        # Fallback: from_json with struct
+        from pyspark.sql.types import StructType, StructField, IntegerType, DoubleType, StringType
+        body_schema = StructType([
+            StructField("brand_id", IntegerType(), True),
+            StructField("total", DoubleType(), True),
+            StructField("driver_id", StringType(), True),
+        ])
+        df_extracted = df.withColumn("body_parsed", f.from_json("body", body_schema)).select(
+            "*",
+            f.col("body_parsed.brand_id").alias("brand_id"),
+            f.col("body_parsed.total").alias("total"),
+            f.col("body_parsed.driver_id").alias("driver_id"),
+        ).drop("body_parsed")
+        print("[FALLBACK] Extracted via from_json + struct")
+
+    # Drop VARIANT column before Iceberg write (Iceberg v2 doesn't support VARIANT type)
+    if "body_variant" in df_extracted.columns:
+        df_extracted = df_extracted.drop("body_variant")
+
+    # Create namespace and table
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.overarch")
+    spark.sql("DROP TABLE IF EXISTS iceberg.gold.orders_variant")
+
+    df_extracted.write.mode("overwrite").saveAsTable("iceberg.gold.orders_variant")
+    print("\n[Iceberg] Created iceberg.gold.orders_variant")
+
+    # Verify
+    count = spark.sql("SELECT COUNT(*) FROM iceberg.gold.orders_variant").collect()[0][0]
+    print(f"\n  Rows written: {count:,}")
+    print("\n  Sample:")
+    spark.sql("""
+        SELECT event_id, event_type, order_id, brand_id, total
+        FROM iceberg.gold.orders_variant
+        WHERE brand_id IS NOT NULL
+        LIMIT 5
+    """).show(truncate=False)
+
+    print("\n" + "=" * 60)
+    print("Demo 1 complete!")
+    print("=" * 60)
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/iceberg_variant.py
+++ b/scripts/demos/showcase/iceberg_variant.py
@@ -99,7 +99,7 @@ def main():
         df_extracted = df_extracted.drop("body_variant")
 
     # Create namespace and table
-    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.overarch")
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.gold")
     spark.sql("DROP TABLE IF EXISTS iceberg.gold.orders_variant")
 
     df_extracted.write.mode("overwrite").saveAsTable("iceberg.gold.orders_variant")

--- a/scripts/demos/showcase/otf_portability.py
+++ b/scripts/demos/showcase/otf_portability.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+"We Have Data" — OTF Portability
+========================================================
+
+
+This script proves that OTF data is fully portable — no vendor lock-in.
+
+Demonstrates:
+  1. Read raw parquet files (dimensions + events) — works anywhere
+  2. Show schemas, row counts, sample data
+  3. Read Iceberg tables if catalog is configured
+  4. Prove the data is complete and usable outside any platform
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/otf_portability.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def main():
+    spark = SparkSession.builder \
+        .appName("lakehouse-demo") \
+        .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("  WE HAVE DATA")
+    print("  Open Table Formats — portable, vendor-neutral, ours.")
+    print("=" * 60)
+    print(f"  Spark version: {spark.version}")
+
+    # ─── Dimension Tables ───────────────────────────────────────
+    section("DIMENSION TABLES (Parquet)")
+
+    dims = {
+        "locations":  "/data/dimensions/locations.parquet",
+        "brands":     "/data/dimensions/brands.parquet",
+        "items":      "/data/dimensions/items.parquet",
+        "categories": "/data/dimensions/categories.parquet",
+    }
+
+    dim_dfs = {}
+    for name, path in dims.items():
+        try:
+            df = spark.read.parquet(path)
+            dim_dfs[name] = df
+            cols = ", ".join([f"{c.name}:{c.dataType.simpleString()}" for c in df.schema])
+            print(f"\n  {name}: {df.count():,} rows")
+            print(f"    Schema: {cols}")
+        except Exception as e:
+            print(f"\n  {name}: NOT FOUND ({e})")
+
+    # Show a taste of the data
+    if "brands" in dim_dfs:
+        print("\n  Sample brands:")
+        dim_dfs["brands"].select("id", "name", "cuisine_type", "momentum").show(5, truncate=False)
+
+    if "locations" in dim_dfs:
+        print("  Sample locations:")
+        dim_dfs["locations"].select("id", "city", "lat", "lon").show(5, truncate=False)
+
+    # ─── Events Table ───────────────────────────────────────────
+    section("EVENT DATA (Parquet)")
+
+    events_path = "/data/events/"
+    try:
+        # Find available parquet files
+        events_df = None
+        for days in ["orders_90d", "orders_30d", "orders_7d", "orders_1d"]:
+            try:
+                events_df = spark.read.parquet(f"{events_path}{days}.parquet")
+                print(f"  Found: {events_path}{days}.parquet")
+                break
+            except Exception:
+                continue
+
+        if events_df is None:
+            print("  No event parquet files found. Run: ./lakehouse testdata generate --days 7")
+            spark.stop()
+            return
+
+        total = events_df.count()
+        print(f"  Total events: {total:,}")
+
+        cols = ", ".join([f"{c.name}:{c.dataType.simpleString()}" for c in events_df.schema])
+        print(f"  Schema: {cols}")
+
+        # Event type distribution
+        print("\n  Event type distribution:")
+        events_df.groupBy("event_type") \
+            .agg(f.count("*").alias("count")) \
+            .orderBy(f.desc("count")) \
+            .show(truncate=False)
+
+        # Order lifecycle sample
+        print("  Sample order lifecycle (single order):")
+        sample_order = events_df.select("order_id").limit(1).collect()[0][0]
+        events_df.filter(f.col("order_id") == sample_order) \
+            .select("sequence", "event_type", "ts") \
+            .orderBy("sequence") \
+            .show(truncate=False)
+
+        # Data quality check — the chaos injection
+        print("  Data quality (chaos injection in test data):")
+        null_location = events_df.filter(f.col("location_id").isNull()).count()
+        null_body = events_df.filter(f.col("body").isNull()).count()
+        null_order = events_df.filter(f.col("order_id").isNull()).count()
+        print(f"    Null location_id: {null_location:,} ({100*null_location/total:.1f}%)")
+        print(f"    Null body:        {null_body:,} ({100*null_body/total:.1f}%)")
+        print(f"    Null order_id:    {null_order:,} ({100*null_order/total:.1f}%)")
+
+        # Parse a JSON body to show the richness
+        print("  Sample event body (order_created):")
+        events_df.filter(
+            (f.col("event_type") == "order_created") & f.col("body").isNotNull()
+        ).select("body").limit(1).show(truncate=False)
+
+    except Exception as e:
+        print(f"  Error reading events: {e}")
+
+    # ─── Iceberg Tables (if catalog configured) ────────────────
+    section("ICEBERG TABLES (if loaded)")
+
+    iceberg_tables = [
+        "iceberg.bronze.orders",
+        "iceberg.bronze.dim_locations",
+        "iceberg.bronze.dim_brands",
+        "iceberg.bronze.dim_items",
+        "iceberg.bronze.dim_categories",
+    ]
+
+    for table in iceberg_tables:
+        try:
+            count = spark.sql(f"SELECT COUNT(*) FROM {table}").collect()[0][0]
+            print(f"  {table}: {count:,} rows")
+        except Exception:
+            print(f"  {table}: not found (run ./lakehouse testdata load)")
+
+    # ─── The Point ──────────────────────────────────────────────
+    section("THE POINT")
+    print("""
+  This data was created on any Spark cluster. It lives in:
+    - Parquet files (open columnar format, readable by anything)
+    - Iceberg tables (open table format, ACID, time travel)
+
+  No Databricks. No vendor lock-in. No proprietary formats.
+  Just open standards on object storage.
+
+  Tools that can read this right now:
+    - Apache Spark (any version >= 3.x)
+    - DuckDB
+    - Trino / Presto
+    - Dremio
+    - Snowflake (external tables)
+    - Polars
+    - pandas + pyarrow
+
+  Next: we need a CATALOG to govern this data.
+    """)
+
+    print("=" * 60)
+    print("  Done.")
+    print("=" * 60 + "\n")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/realtime_mode.py
+++ b/scripts/demos/showcase/realtime_mode.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Real-Time Mode (RTM) + SDP Streaming
+==============================================================
+
+streaming in Spark 4.1 Structured Streaming. 
+
+Demonstrates:
+  1. BEFORE: Micro-batch with trigger(processingTime='10 seconds') — fixed scheduling
+  2. AFTER: Real-Time Mode with trigger(realTime='5 minutes') — sub-second latency
+  3. Latency comparison via Foreach sink that prints metrics
+  4. SDP + Streaming: how @dp.table() works with streaming sources
+
+RTM in OSS Spark 4.1: stateless, single-stage, Kafka source, Kafka/Foreach sinks.
+Python support may be limited — includes fallback to processingTime if RTM unavailable.
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        --packages org.apache.spark:spark-sql-kafka-0-10_2.13:4.1.0 \
+        /scripts/demos/showcase/realtime_mode.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata load
+    ./lakehouse producer   # In another terminal — produces to Kafka "orders" topic
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+from pyspark.sql.types import (
+    StructType, StructField, StringType, IntegerType,
+)
+
+# Order event schema (ghost kitchen food delivery)
+ORDER_SCHEMA = StructType([
+    StructField("event_id", StringType()),
+    StructField("event_type", StringType()),
+    StructField("ts", StringType()),
+    StructField("order_id", StringType()),
+    StructField("location_id", IntegerType()),
+    StructField("sequence", IntegerType()),
+    StructField("body", StringType()),
+])
+
+KAFKA_BOOTSTRAP = "localhost:9092"
+KAFKA_TOPIC = "orders"
+CHECKPOINT_MICRO = "/tmp/checkpoints/rtm_demo_micro"
+CHECKPOINT_RTM = "/tmp/checkpoints/rtm_demo_rtm"
+
+
+class LatencyMetricsWriter:
+    """ForeachWriter that prints latency metrics for live demo."""
+
+    def __init__(self, mode_name: str):
+        self.mode_name = mode_name
+        self.count = 0
+        self.latencies_ms = []
+
+    def open(self, partition_id, epoch_id):
+        return True
+
+    def process(self, row):
+        self.count += 1
+        try:
+            from datetime import datetime
+            proc_ts = datetime.now()
+            event_ts = row["event_timestamp"]
+            if event_ts:
+                latency_ms = (proc_ts - event_ts).total_seconds() * 1000
+                self.latencies_ms.append(latency_ms)
+                if self.count <= 5 or self.count % 10 == 0:
+                    print(f"  [{self.mode_name}] row {self.count}: order_id={row['order_id']} "
+                          f"event_type={row['event_type']} latency={latency_ms:.0f}ms")
+        except Exception as e:
+            print(f"  [{self.mode_name}] row {self.count}: (latency calc skipped: {e})")
+
+    def close(self, error):
+        if error:
+            print(f"  [{self.mode_name}] ForeachWriter closed with error: {error}")
+        elif self.latencies_ms:
+            avg = sum(self.latencies_ms) / len(self.latencies_ms)
+            p99 = sorted(self.latencies_ms)[int(len(self.latencies_ms) * 0.99)] if len(self.latencies_ms) > 10 else max(self.latencies_ms)
+            print(f"  [{self.mode_name}] Batch complete: {self.count} rows, avg_latency={avg:.0f}ms, p99≈{p99:.0f}ms")
+
+
+def create_kafka_stream(spark):
+    """Create Kafka readStream for orders topic."""
+    return (
+        spark.readStream.format("kafka")
+        .option("kafka.bootstrap.servers", KAFKA_BOOTSTRAP)
+        .option("subscribe", KAFKA_TOPIC)
+        .option("startingOffsets", "latest")
+        .option("failOnDataLoss", "false")
+        .load()
+    )
+
+
+def parse_and_add_latency(stream_df):
+    """Parse JSON, add event_timestamp and latency placeholder."""
+    parsed = (
+        stream_df.select(
+            f.from_json(f.col("value").cast("string"), ORDER_SCHEMA).alias("data")
+        )
+        .select("data.*")
+        .withColumn("event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " ")))
+    )
+    return parsed
+
+
+def run_micro_batch_demo(spark, run_seconds: int = 15):
+    """BEFORE: Micro-batch with processingTime trigger."""
+    print("\n" + "=" * 70)
+    print("  BEFORE: MICRO-BATCH MODE")
+    print("  trigger(processingTime='10 seconds') — fixed scheduling, higher latency")
+    print("=" * 70)
+
+    stream = create_kafka_stream(spark)
+    parsed = parse_and_add_latency(stream)
+
+    writer = LatencyMetricsWriter("micro-batch")
+    try:
+        query = (
+            parsed.writeStream
+            .foreach(writer)
+            .outputMode("update")
+            .option("checkpointLocation", CHECKPOINT_MICRO)
+            .trigger(processingTime="10 seconds")
+            .start()
+        )
+        print("  Started micro-batch query. Waiting {} seconds for events...".format(run_seconds))
+        print("  (Ensure ./lakehouse producer is running in another terminal)")
+        query.awaitTermination(run_seconds)
+        query.stop()
+    except Exception as e:
+        print(f"  Micro-batch demo error: {e}")
+        raise
+
+
+def run_realtime_mode_demo(spark, run_seconds: int = 15):
+    """AFTER: Real-Time Mode with realTime trigger (or fallback)."""
+    print("\n" + "=" * 70)
+    print("  AFTER: REAL-TIME MODE (RTM)")
+    print("  trigger(realTime='5 minutes') — sub-second latency, streaming shuffle")
+    print("=" * 70)
+
+    stream = create_kafka_stream(spark)
+    parsed = parse_and_add_latency(stream)
+
+    writer = LatencyMetricsWriter("RTM")
+    rtm_available = False
+
+    try:
+        # Try RTM trigger first (OSS Spark 4.1 may not have it)
+        query = (
+            parsed.writeStream
+            .foreach(writer)
+            .outputMode("update")
+            .option("checkpointLocation", CHECKPOINT_RTM)
+            .trigger(realTime="5 minutes")
+            .start()
+        )
+        rtm_available = True
+        print("  Real-Time Mode trigger accepted! Running RTM query...")
+    except (TypeError, AttributeError) as e:
+        print("  Real-Time Mode trigger not available in this Spark build.")
+        print("  (RTM is GA in Databricks Runtime 16.4+; OSS Spark 4.1 has limited support)")
+        print("  Falling back to trigger(processingTime='1 second') for demo.")
+        query = (
+            parsed.writeStream
+            .foreach(writer)
+            .outputMode("update")
+            .option("checkpointLocation", CHECKPOINT_RTM)
+            .trigger(processingTime="1 second")
+            .start()
+        )
+
+    print("  Waiting {} seconds for events...".format(run_seconds))
+    try:
+        query.awaitTermination(run_seconds)
+    finally:
+        query.stop()
+
+    return rtm_available
+
+
+def main():
+    spark = (
+        SparkSession.builder
+        .appName("lakehouse-demo")
+        .config("spark.sql.streaming.schemaInference", "true")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "#" * 70)
+    print("#  REAL-TIME MODE (RTM) — CO-HEADLINER WITH SDP")
+    print("#  Spark 4.1 Structured Streaming: micro-batch vs real-time")
+    print("#" * 70)
+    print(f"\n  Spark version: {spark.version}")
+    print("  Kafka: {} topic '{}'".format(KAFKA_BOOTSTRAP, KAFKA_TOPIC))
+
+    # Act 1: Micro-batch (BEFORE)
+    run_micro_batch_demo(spark, run_seconds=12)
+
+    # Act 2: Real-Time Mode (AFTER)
+    rtm_worked = run_realtime_mode_demo(spark, run_seconds=12)
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("  SUMMARY")
+    print("=" * 70)
+    print("  Micro-batch: Fixed 10s intervals. Latency = scheduling delay + processing.")
+    print("  Real-Time Mode: Events processed as they arrive. p99 in single-digit ms.")
+    if rtm_worked:
+        print("  RTM enabled! Same API, one line change: .trigger(realTime='5 minutes')")
+    else:
+        print("  RTM not in this build. On Databricks Runtime 16.4+: full RTM support.")
+    print("  Flink killer: RTM outperformed Flink by up to 92% in benchmarks.")
+    print("  SDP connection: In SDP, streaming is @dp.table. With RTM, that runs sub-second.")
+    print("=" * 70)
+    print("\n" + "#" * 70)
+    print("#  RTM Demo complete!")
+    print("#" * 70 + "\n")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/sdp-pipeline.yml
+++ b/scripts/demos/showcase/sdp-pipeline.yml
@@ -1,0 +1,9 @@
+name: sdp_demo_pipeline
+libraries:
+  - glob:
+      include: sdp_demo.py
+catalog: iceberg
+database: bronze
+storage: file:///tmp/sdp-demo-checkpoint
+configuration:
+  spark.sql.shuffle.partitions: "8"

--- a/scripts/demos/showcase/sdp_demo.py
+++ b/scripts/demos/showcase/sdp_demo.py
@@ -1,0 +1,168 @@
+"""SDP Demo — Clean Medallion Pipeline
+=====================================================
+
+Shows Spark Declarative Pipelines building silver and gold layers
+on top of existing Iceberg bronze tables + live Kafka streaming.
+
+Bronze (already exists):
+  - iceberg.bronze.orders          — batch order events (loaded earlier)
+  - iceberg.bronze.dim_locations   — delivery cities
+  - iceberg.bronze.dim_brands      — ghost kitchen brands
+
+This pipeline adds:
+  - bronze.orders_streaming        — live Kafka ingest (@dp.table)
+  - silver.orders_enriched         — cleaned, joined with locations
+  - gold.hourly_metrics            — order counts + revenue by city/hour
+  - gold.brand_summary             — brand-level KPIs
+
+Run:
+    spark-pipelines run --spec scripts/demos/showcase/sdp-pipeline.yml
+
+    # Or dry-run to see the dependency graph:
+    spark-pipelines dry-run --spec scripts/demos/showcase/sdp-pipeline.yml
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load       # populates bronze tables
+    ./lakehouse producer            # (optional) start Kafka stream
+"""
+
+from pyspark import pipelines as dp
+from pyspark.sql import SparkSession, functions as f
+from pyspark.sql.types import (
+    StructType, StructField, StringType, IntegerType, DoubleType,
+)
+
+
+def get_spark():
+    """Get the active SparkSession (provided by SDP framework)."""
+    return SparkSession.getActiveSession()
+
+
+# =============================================================================
+# BRONZE — Streaming ingest from Kafka
+# =============================================================================
+
+@dp.table(name="bronze.orders_streaming")
+def orders_streaming():
+    """Live order events from Kafka. Runs continuously."""
+    schema = StructType([
+        StructField("event_id", StringType()),
+        StructField("event_type", StringType()),
+        StructField("ts", StringType()),
+        StructField("ts_seconds", IntegerType()),
+        StructField("order_id", StringType()),
+        StructField("location_id", IntegerType()),
+        StructField("sequence", IntegerType()),
+        StructField("body", StringType()),
+    ])
+
+    return (
+        get_spark().readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", "localhost:9092")
+        .option("subscribe", "orders")
+        .option("startingOffsets", "latest")
+        .load()
+        .select(
+            f.from_json(f.col("value").cast("string"), schema).alias("e"),
+            f.col("timestamp").alias("kafka_timestamp"),
+        )
+        .select(
+            "e.event_id",
+            "e.event_type",
+            f.coalesce(
+                f.try_to_timestamp("e.ts", f.lit("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")),
+                f.try_to_timestamp("e.ts", f.lit("yyyy-MM-dd'T'HH:mm:ss")),
+            ).alias("event_timestamp"),
+            "e.order_id",
+            "e.location_id",
+            "e.sequence",
+            "e.body",
+            "kafka_timestamp",
+        )
+    )
+
+
+# =============================================================================
+# SILVER — Enrichment
+# =============================================================================
+
+@dp.materialized_view(name="silver.orders_enriched")
+def orders_enriched():
+    """Orders enriched with city name and parsed order details.
+
+    Reads from batch bronze table. Joins with dim_locations.
+    Extracts brand_id and total from JSON body.
+    """
+    orders = get_spark().table("iceberg.bronze.orders")
+    locations = get_spark().table("iceberg.bronze.dim_locations").select(
+        f.col("id").alias("location_id"),
+        f.col("city"),
+    )
+
+    return (
+        orders
+        .filter(f.col("event_id").isNotNull())
+        .join(locations, on="location_id", how="left")
+        .select(
+            "event_id",
+            "event_type",
+            "event_timestamp",
+            "order_id",
+            "location_id",
+            "city",
+            "sequence",
+            f.get_json_object("body", "$.brand_id").cast("int").alias("brand_id"),
+            f.get_json_object("body", "$.total").cast("double").alias("order_total"),
+            f.to_date("event_timestamp").alias("event_date"),
+            f.hour("event_timestamp").alias("event_hour"),
+        )
+    )
+
+
+# =============================================================================
+# GOLD — Aggregations
+# =============================================================================
+
+@dp.materialized_view(name="gold.hourly_metrics")
+def hourly_metrics():
+    """Hourly order volume and revenue by city."""
+    return (
+        get_spark().table("iceberg.silver.orders_enriched")
+        .filter(f.col("event_type") == "order_created")
+        .groupBy("event_date", "event_hour", "city")
+        .agg(
+            f.count("order_id").alias("order_count"),
+            f.sum("order_total").alias("total_revenue"),
+            f.avg("order_total").alias("avg_order_value"),
+        )
+    )
+
+
+@dp.materialized_view(name="gold.brand_summary")
+def brand_summary():
+    """Brand-level summary: orders, revenue, reach."""
+    orders = get_spark().table("iceberg.silver.orders_enriched")
+    brands = get_spark().table("iceberg.bronze.dim_brands").select(
+        f.col("id").alias("brand_id"),
+        f.col("name").alias("brand_name"),
+    )
+
+    return (
+        orders
+        .filter(f.col("event_type") == "order_created")
+        .groupBy("brand_id")
+        .agg(
+            f.count("order_id").alias("total_orders"),
+            f.sum("order_total").alias("total_revenue"),
+            f.avg("order_total").alias("avg_order_value"),
+            f.countDistinct("city").alias("cities_served"),
+        )
+        .join(brands, on="brand_id", how="left")
+        .select(
+            "brand_id", "brand_name",
+            "total_orders", "total_revenue", "avg_order_value", "cities_served",
+        )
+    )

--- a/scripts/demos/showcase/sdp_showcase.py
+++ b/scripts/demos/showcase/sdp_showcase.py
@@ -160,7 +160,7 @@ class DeclarativePipeline:
         return results
 
 
-pipeline = DeclarativePipeline("overarchitected_sdp", catalog="iceberg")
+pipeline = DeclarativePipeline("lakehouse_sdp", catalog="iceberg")
 
 
 def act2_declarative(spark):

--- a/scripts/demos/showcase/sdp_showcase.py
+++ b/scripts/demos/showcase/sdp_showcase.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Spark Declarative Pipelines (SDP) Showcase
+===================================================================
+
+pipeline development in Spark 4.1. 
+
+Three acts:
+  1. "The Old Way" — imperative pipeline with manual ordering
+  2. "The New Way" — SDP with @dp.materialized_view, auto-dependency resolution
+  3. "Live Extension" — add a new gold table with zero execution logic changes
+
+This script simulates SDP behavior for live demo purposes. The real SDP pipeline
+lives at scripts/pipelines/pipeline_sdp.py and runs via:
+    spark-pipelines run --spec scripts/pipelines/spark-pipeline.yml
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/sdp_showcase.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+from pyspark.sql.types import (
+    StructType, StructField, StringType, IntegerType, DoubleType,
+)
+from functools import wraps
+from typing import Callable, Dict, List, Set
+import re
+import textwrap
+
+
+# =============================================================================
+# "The Old Way" (Imperative)
+# =============================================================================
+
+def act1_imperative(spark):
+    """Show the imperative approach — manual ordering, explicit writes."""
+    print("\n" + "=" * 70)
+    print("  THE OLD WAY (Imperative)")
+    print("  You manage execution order. You write to tables. You handle deps.")
+    print("=" * 70)
+
+    print(textwrap.dedent("""
+    # What imperative code looks like:
+    #
+    #   def load_orders(spark):
+    #       df = spark.read.parquet("/data/orders.parquet")
+    #       df.write.mode("overwrite").saveAsTable("bronze.orders")  # explicit write
+    #
+    #   def enrich_orders(spark):
+    #       orders = spark.table("bronze.orders")      # must run AFTER load_orders
+    #       locations = spark.table("dim_locations")
+    #       enriched = orders.join(locations, "location_id")
+    #       enriched.write.mode("overwrite").saveAsTable("silver.orders")  # explicit write
+    #
+    #   # YOU manage execution order:
+    #   load_orders(spark)      # 1st
+    #   enrich_orders(spark)    # 2nd — wrong order = crash
+    #   daily_metrics(spark)    # 3rd
+    """))
+
+    df = spark.read.parquet("/data/events/orders_90d.parquet").limit(2000)
+    df = df.withColumn("event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " ")))
+
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.demo_imperative")
+    spark.sql("DROP TABLE IF EXISTS iceberg.demo_imperative.bronze_orders")
+    df.write.mode("overwrite").saveAsTable("iceberg.demo_imperative.bronze_orders")
+
+    count = spark.table("iceberg.demo_imperative.bronze_orders").count()
+    print(f"  [imperative] Wrote {count:,} rows to bronze_orders")
+    print("  Problems: manual ordering, explicit writes, fragile dependencies\n")
+
+
+# =============================================================================
+# "The New Way" (Spark Declarative Pipelines)
+# =============================================================================
+
+class DeclarativePipeline:
+    """Mini SDP framework for live demo. Production uses: from pyspark import pipelines as dp"""
+
+    def __init__(self, name: str, catalog: str = "iceberg"):
+        self.name = name
+        self.catalog = catalog
+        self.tables: Dict[str, dict] = {}
+        self._spark: SparkSession = None
+
+    def set_spark(self, spark: SparkSession):
+        self._spark = spark
+
+    @property
+    def spark(self) -> SparkSession:
+        return self._spark
+
+    def materialized_view(self, name: str):
+        """Register a table definition — just like @dp.materialized_view."""
+        def decorator(func: Callable):
+            import inspect
+            source = inspect.getsource(func)
+            deps = set(re.findall(r'spark\.table\(["\']([^"\']+)["\']\)', source))
+
+            self.tables[name] = {'func': func, 'deps': deps}
+
+            @wraps(func)
+            def wrapper():
+                return func()
+            return wrapper
+        return decorator
+
+    def _topo_sort(self) -> List[str]:
+        visited: Set[str] = set()
+        order: List[str] = []
+
+        def visit(name: str):
+            if name in visited:
+                return
+            visited.add(name)
+            if name in self.tables:
+                for dep in self.tables[name]['deps']:
+                    short = dep.replace(f"{self.catalog}.", "")
+                    visit(short)
+            order.append(name)
+
+        for t in self.tables:
+            visit(t)
+        return order
+
+    def run(self) -> Dict[str, int]:
+        results = {}
+        order = self._topo_sort()
+
+        print(f"\n  Execution order (AUTO-RESOLVED): {order}")
+        print(f"  Tables registered: {len(self.tables)}")
+
+        for name in order:
+            if name not in self.tables:
+                continue
+            info = self.tables[name]
+            full_name = f"{self.catalog}.{name}"
+            deps = info['deps']
+
+            layer = name.split(".")[0].upper()
+            dep_str = f" <- {deps}" if deps else " (no deps)"
+            print(f"    [{layer}] {name}{dep_str}")
+
+            df = info['func']()
+            self._spark.sql(f"CREATE NAMESPACE IF NOT EXISTS {self.catalog}.{name.split('.')[0]}")
+            self._spark.sql(f"DROP TABLE IF EXISTS {full_name}")
+            df.write.mode("overwrite").saveAsTable(full_name)
+
+            count = self._spark.sql(f"SELECT COUNT(*) FROM {full_name}").collect()[0][0]
+            results[name] = count
+            print(f"           -> {count:,} rows")
+
+        return results
+
+
+pipeline = DeclarativePipeline("overarchitected_sdp", catalog="iceberg")
+
+
+def act2_declarative(spark):
+    """Show the SDP approach — define WHAT, Spark handles WHEN and HOW."""
+    print("\n" + "=" * 70)
+    print("  THE NEW WAY (Spark Declarative Pipelines)")
+    print("  Define WHAT each table contains. Spark handles execution order.")
+    print("=" * 70)
+
+    print(textwrap.dedent("""
+    # What SDP code looks like:
+    #
+    #   from pyspark import pipelines as dp
+    #
+    #   @dp.materialized_view(name="bronze.orders")
+    #   def orders():
+    #       return spark.read.parquet("/data/orders.parquet")  # just RETURN
+    #
+    #   @dp.materialized_view(name="silver.orders_enriched")
+    #   def orders_enriched():
+    #       orders = spark.table("iceberg.bronze.orders")       # dep auto-detected!
+    #       locations = spark.table("iceberg.bronze.dim_locations")
+    #       return orders.join(broadcast(locations), "location_id")  # just RETURN
+    #
+    #   # Run: spark-pipelines run --spec pipeline.yml
+    #   # No manual ordering. No explicit writes. Framework handles everything.
+    """))
+
+    pipeline.set_spark(spark)
+
+    # Register tables — ORDER DOES NOT MATTER (that's the point)
+    @pipeline.materialized_view(name="bronze.dim_locations")
+    def dim_locations():
+        return spark.read.parquet("/data/dimensions/locations.parquet")
+
+    @pipeline.materialized_view(name="bronze.orders")
+    def orders():
+        df = spark.read.parquet("/data/events/orders_90d.parquet").limit(3000)
+        return df.withColumn("event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " ")))
+
+    body_schema = StructType([
+        StructField("brand_id", IntegerType(), True),
+        StructField("total", DoubleType(), True),
+        StructField("driver_id", StringType(), True),
+    ])
+
+    @pipeline.materialized_view(name="silver.orders_enriched")
+    def orders_enriched():
+        orders = spark.table("iceberg.bronze.orders")
+        locations = spark.table("iceberg.bronze.dim_locations").select(
+            f.col("id").alias("location_id"), f.col("city").alias("city_name")
+        )
+
+        enriched = orders.withColumn("body_parsed", f.from_json("body", body_schema))
+        enriched = enriched.select(
+            "*",
+            f.col("body_parsed.brand_id").alias("brand_id"),
+            f.col("body_parsed.total").alias("order_total"),
+        ).drop("body_parsed")
+        enriched = enriched.withColumns({
+            "event_hour": f.hour("event_timestamp"),
+            "event_date": f.to_date("event_timestamp"),
+        })
+        return enriched.join(f.broadcast(locations), on="location_id", how="left")
+
+    @pipeline.materialized_view(name="gold.hourly_metrics")
+    def hourly_metrics():
+        orders = spark.table("iceberg.silver.orders_enriched")
+        return orders.filter(f.col("event_type") == "order_created").groupBy(
+            "event_date", "event_hour", "city_name"
+        ).agg(
+            f.count("order_id").alias("order_count"),
+            f.sum("order_total").alias("total_revenue"),
+            f.avg("order_total").alias("avg_order_value"),
+        )
+
+    print("  Running pipeline (framework resolves order automatically)...\n")
+    results = pipeline.run()
+
+    print(f"\n  Pipeline complete: {len(results)} tables, zero manual ordering")
+    print("\n  Sample gold.hourly_metrics:")
+    spark.table("iceberg.gold.hourly_metrics").orderBy(f.desc("total_revenue")).show(5, truncate=False)
+
+
+# =============================================================================
+# "Live Extension" (Add a table — no execution logic changes)
+# =============================================================================
+
+def act3_live_extension(spark):
+    """The money shot: add a new gold table live. Zero changes to execution logic."""
+    print("\n" + "=" * 70)
+    print("  LIVE EXTENSION")
+    print("  Add a new gold table. No changes to pipeline runner. Just define it.")
+    print("=" * 70)
+
+    @pipeline.materialized_view(name="gold.city_leaderboard")
+    def city_leaderboard():
+        """Which city orders the most? Added live on the show."""
+        orders = spark.table("iceberg.silver.orders_enriched")
+        return orders.filter(f.col("event_type") == "order_created").groupBy(
+            "city_name"
+        ).agg(
+            f.count("order_id").alias("total_orders"),
+            f.sum("order_total").alias("total_revenue"),
+            f.avg("order_total").alias("avg_order_value"),
+        ).orderBy(f.desc("total_orders"))
+
+    print("\n  Registered gold.city_leaderboard — re-running pipeline...\n")
+    results = pipeline.run()
+
+    print(f"\n  Pipeline complete: {len(results)} tables (was 4, now 5)")
+    print("\n  NEW TABLE — gold.city_leaderboard:")
+    spark.table("iceberg.gold.city_leaderboard").show(10, truncate=False)
+
+    print(textwrap.dedent("""
+    KEY TAKEAWAY:
+      - Imperative: add table → update execution order → test order → pray
+      - SDP: add @dp.materialized_view → done. Framework handles the rest.
+
+    REAL SDP COMMANDS:
+      spark-pipelines dry-run --spec pipeline.yml   # validate
+      spark-pipelines run --spec pipeline.yml        # execute
+      spark-pipelines graph --spec pipeline.yml      # visualize DAG
+    """))
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+def main():
+    spark = SparkSession.builder.appName("lakehouse-demo").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "#" * 70)
+    print("#  SPARK DECLARATIVE PIPELINES (SDP) — THE HEADLINE FEATURE")
+    print(f"#  Spark {spark.version}")
+    print("#" * 70)
+
+    act1_imperative(spark)
+    act2_declarative(spark)
+    act3_live_extension(spark)
+
+    print("\n" + "#" * 70)
+    print("#  SDP Showcase complete!")
+    print("#  Real pipeline: scripts/pipelines/pipeline_sdp.py")
+    print("#  Real config:   scripts/pipelines/spark-pipeline.yml")
+    print("#" * 70 + "\n")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/spark41_feature_tour.py
+++ b/scripts/demos/showcase/spark41_feature_tour.py
@@ -45,7 +45,7 @@ def main():
         return
 
     # Create namespaces
-    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.overarch")
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.gold")
 
     # Step 1: VARIANT body (or from_json fallback)
     orders_ts = orders.withColumn(

--- a/scripts/demos/showcase/spark41_feature_tour.py
+++ b/scripts/demos/showcase/spark41_feature_tour.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Full Over-Architected Pipeline
+======================================================
+
+Combines multiple Spark 4.1 features in one script:
+1. VARIANT/parse_json for flexible body parsing
+2. Recursive CTE for event chain traversal
+3. Collation for case-insensitive brand search (when available)
+4. SDP-style declarative table definitions
+5. Iceberg writes with partitioning
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/spark41_feature_tour.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType
+
+def main():
+    spark = SparkSession.builder.appName("lakehouse-demo").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("Full Pipeline")
+    print("=" * 60)
+    print(f"Spark version: {spark.version}")
+
+    # Ensure we have data - run pipeline_spark41 first or use sample
+    try:
+        orders = spark.read.parquet("/data/events/orders_90d.parquet")
+        dim_locations = spark.read.parquet("/data/dimensions/locations.parquet")
+        dim_brands = spark.read.parquet("/data/dimensions/brands.parquet")
+        print("Loaded parquet sources")
+    except Exception:
+        print("Parquet not found - ensure testdata is loaded")
+        spark.stop()
+        return
+
+    # Create namespaces
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.overarch")
+
+    # Step 1: VARIANT body (or from_json fallback)
+    orders_ts = orders.withColumn(
+        "event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " "))
+    ).limit(5000)
+
+    try:
+        orders_variant = orders_ts.withColumn("body_variant", f.try_parse_json("body"))
+        orders_extracted = orders_variant.withColumn(
+            "brand_id", f.expr("try_variant_get(body_variant, '$.brand_id', 'int')")
+        ).withColumn(
+            "order_total", f.expr("try_variant_get(body_variant, '$.total', 'double')")
+        )
+        print("\n[1] VARIANT: Parsed body with try_parse_json + try_variant_get")
+    except Exception:
+        body_schema = StructType([
+            StructField("brand_id", IntegerType(), True),
+            StructField("total", DoubleType(), True),
+        ])
+        orders_extracted = orders_ts.withColumn("body_parsed", f.from_json("body", body_schema)).select(
+            "*", f.col("body_parsed.brand_id").alias("brand_id"),
+            f.col("body_parsed.total").alias("order_total"),
+        ).drop("body_parsed")
+        print("\n[1] FALLBACK: Parsed body with from_json")
+
+    # Drop VARIANT column before Iceberg write (Iceberg v2 doesn't support VARIANT type)
+    if "body_variant" in orders_extracted.columns:
+        orders_extracted = orders_extracted.drop("body_variant")
+
+    # Join locations
+    loc_lookup = dim_locations.select(
+        f.col("id").alias("location_id"), f.col("city").alias("city_name")
+    )
+    enriched = orders_extracted.join(f.broadcast(loc_lookup), on="location_id", how="left")
+
+    # Step 2: Recursive CTE for event chain
+    enriched.createOrReplaceTempView("order_events")
+
+    try:
+        chain_df = spark.sql("""
+            WITH RECURSIVE event_chain AS (
+                SELECT order_id, event_id, event_type, event_timestamp, sequence, 1 AS depth
+                FROM order_events WHERE sequence = 0
+                UNION ALL
+                SELECT e.order_id, e.event_id, e.event_type, e.event_timestamp, e.sequence, c.depth + 1
+                FROM order_events e
+                JOIN event_chain c ON e.order_id = c.order_id AND e.sequence = c.sequence + 1
+            )
+            SELECT order_id, event_type, event_timestamp, depth
+            FROM event_chain
+            WHERE order_id IN (SELECT DISTINCT order_id FROM order_events LIMIT 10)
+            ORDER BY order_id, depth
+        """)
+        print("\n[2] Recursive CTE: Event chain traversal")
+        chain_df.show(20, truncate=False)
+    except Exception as e:
+        print(f"\n[2] Recursive CTE skipped: {e}")
+
+    # Step 3: Collation (case-insensitive brand search)
+    dim_brands.createOrReplaceTempView("brands")
+    try:
+        collation_df = spark.sql("""
+            SELECT name, name COLLATE utf8_lcase AS name_lower
+            FROM brands
+            WHERE name COLLATE utf8_lcase LIKE '%pizza%' OR name COLLATE utf8_lcase LIKE '%burger%'
+        """)
+        print("\n[3] Collation: Case-insensitive brand search")
+        collation_df.show(truncate=False)
+    except Exception as e:
+        print(f"\n[3] Collation skipped: {e}")
+        collation_df = spark.sql("SELECT name FROM brands WHERE LOWER(name) LIKE '%pizza%' OR LOWER(name) LIKE '%burger%'")
+        collation_df.show(truncate=False)
+
+    # Step 4: Gold aggregations (SDP-style logic)
+    gold_hourly = enriched.filter(f.col("event_type") == "order_created").groupBy(
+        f.to_date("event_timestamp").alias("event_date"),
+        f.hour("event_timestamp").alias("event_hour"),
+        "location_id", "city_name"
+    ).agg(
+        f.count("order_id").alias("order_count"),
+        f.sum("order_total").alias("total_revenue"),
+        f.avg("order_total").alias("avg_order_value"),
+    )
+    print("\n[4] Gold: hourly_metrics aggregation")
+
+    gold_brand = enriched.filter(f.col("event_type") == "order_created").groupBy("brand_id").agg(
+        f.count("order_id").alias("total_orders"),
+        f.sum("order_total").alias("total_revenue"),
+    ).join(
+        dim_brands.select(f.col("id").alias("brand_id"), "name"),
+        on="brand_id", how="left"
+    )
+    print("     brand_summary aggregation")
+
+    # Step 5: Write to Iceberg
+    spark.sql("DROP TABLE IF EXISTS iceberg.gold.gold_hourly")
+    spark.sql("DROP TABLE IF EXISTS iceberg.gold.gold_brand")
+
+    gold_hourly.write.mode("overwrite").saveAsTable("iceberg.gold.gold_hourly")
+    gold_brand.write.mode("overwrite").saveAsTable("iceberg.gold.gold_brand")
+
+    print("\n[5] Iceberg: Written iceberg.gold.gold_hourly, iceberg.gold.gold_brand")
+
+    # Summary
+    h_count = spark.table("iceberg.gold.gold_hourly").count()
+    b_count = spark.table("iceberg.gold.gold_brand").count()
+    print(f"\n  gold_hourly: {h_count} rows")
+    print(f"  gold_brand: {b_count} rows")
+
+    print("\n  Sample gold_hourly:")
+    spark.table("iceberg.gold.gold_hourly").orderBy(f.desc("total_revenue")).show(5, truncate=False)
+
+    print("\n" + "=" * 60)
+    print("Demo 3 complete! All features wired together.")
+    print("=" * 60)
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/spark_cluster_diagnostic.py
+++ b/scripts/demos/showcase/spark_cluster_diagnostic.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+"We Need Compute" — Spark 4.1 Setup + Features
+======================================================================
+
+Now they need a compute engine.
+This script walks through Spark 4.1 configuration and demonstrates
+the headline features on Casper's Kitchen data.
+
+Demonstrates:
+  1. Spark configuration walkthrough (what goes in spark-defaults.conf)
+  2. VARIANT type — parse_json, try_variant_get on order bodies
+  3. Recursive CTE — event chain traversal
+  4. Collation — case-insensitive brand search
+  5. Spark Connect — thin client introduction
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/spark_cluster_diagnostic.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def act3_config_walkthrough(spark):
+    """Step 1: What does spark-defaults.conf actually look like?"""
+    section("STEP 1: Spark Configuration (The Confusing Part)")
+
+    print(f"""
+  A user asks: "What config do I actually need?"
+
+  Spark version: {spark.version}
+
+  spark-defaults.conf for Iceberg + S3-compatible storage:
+
+  # ─── Catalog (tells Spark where tables live) ───
+  spark.sql.catalog.iceberg                       org.apache.iceberg.spark.SparkCatalog
+
+  # Option A: JDBC catalog (direct to PostgreSQL)
+  spark.sql.catalog.iceberg.type                  jdbc
+  spark.sql.catalog.iceberg.uri                   jdbc:postgresql://localhost:5432/iceberg_catalog
+  spark.sql.catalog.iceberg.jdbc.user             iceberg
+  spark.sql.catalog.iceberg.jdbc.password         iceberg_password
+
+  # Option B: REST catalog (Unity Catalog)
+  spark.sql.catalog.iceberg.catalog-impl          org.apache.iceberg.rest.RESTCatalog
+  spark.sql.catalog.iceberg.uri                   http://localhost:8081/api/2.1/unity-catalog/iceberg
+
+  # ─── Storage (S3-compatible, points to SeaweedFS) ───
+  spark.sql.catalog.iceberg.warehouse             s3a://lakehouse/warehouse
+  spark.hadoop.fs.s3a.endpoint                    http://localhost:8333
+  spark.hadoop.fs.s3a.access.key                  admin
+  spark.hadoop.fs.s3a.secret.key                  admin_password
+  spark.hadoop.fs.s3a.path.style.access           true
+
+  # ─── JARs (the real pain point) ───
+  spark.jars                                      /opt/spark/jars-extra/iceberg-spark-runtime-4.0_2.13-1.10.0.jar,
+                                                  /opt/spark/jars-extra/aws-bundle-*.jar,
+                                                  /opt/spark/jars-extra/postgresql-*.jar
+
+  A user asks: "That's... a lot of config."
+  Nick: "Welcome to open source."
+
+  Key versions (don't change without testing):
+    - Iceberg: 1.10.0
+    - AWS SDK v2: 2.24.6 (exact for Hadoop 3.4.1)
+    - Spark: 4.1.0 (Scala 2.13, Java 21)
+    """)
+
+
+def act3_variant_type(spark):
+    """Step 2: VARIANT type — flexible schema for JSON bodies."""
+    section("STEP 2: VARIANT Type (Spark 4.1)")
+
+    print("""
+  The order event `body` field is a JSON string with different schemas
+  per event type. VARIANT lets us parse it without declaring a schema upfront.
+
+  Old way: from_json(body, explicit_schema) — breaks if schema changes
+  New way: parse_json(body) → VARIANT — schema-on-read, always works
+    """)
+
+    orders = spark.read.parquet("/data/events/orders_90d.parquet").limit(3000)
+    orders = orders.withColumn(
+        "event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " "))
+    )
+
+    # try_parse_json handles malformed JSON gracefully (returns null instead of error)
+    try:
+        df = orders.withColumn("body_variant", f.try_parse_json("body"))
+        print("  Using try_parse_json() → VARIANT type")
+
+        # Extract fields with try_variant_get (safe — returns null on missing path)
+        df_extracted = df.withColumn(
+            "brand_id", f.expr("try_variant_get(body_variant, '$.brand_id', 'int')")
+        ).withColumn(
+            "total", f.expr("try_variant_get(body_variant, '$.total', 'double')")
+        ).withColumn(
+            "driver_id", f.expr("try_variant_get(body_variant, '$.driver_id', 'string')")
+        ).withColumn(
+            "delivery_lat", f.expr("try_variant_get(body_variant, '$.delivery_lat', 'double')")
+        )
+        print("  Extracted: brand_id, total, driver_id, delivery_lat via try_variant_get()")
+
+        # Show different event types extracting different fields
+        print("\n  order_created events (brand_id + total populated):")
+        df_extracted.filter(
+            (f.col("event_type") == "order_created") & f.col("brand_id").isNotNull()
+        ).select("order_id", "event_type", "brand_id", "total").show(5, truncate=False)
+
+        print("  delivered events (delivery_lat populated):")
+        df_extracted.filter(
+            (f.col("event_type") == "delivered") & f.col("delivery_lat").isNotNull()
+        ).select("order_id", "event_type", "delivery_lat", "total").show(5, truncate=False)
+
+        print("  Key insight: same column, same query, different fields per event type.")
+        print("  No schema explosion. No union of 8 different schemas.")
+
+    except (AttributeError, Exception) as e:
+        print(f"  VARIANT not available in this build: {e}")
+        print("  Falling back to from_json with explicit schema...")
+        body_schema = StructType([
+            StructField("brand_id", IntegerType(), True),
+            StructField("total", DoubleType(), True),
+            StructField("driver_id", StringType(), True),
+        ])
+        df_extracted = orders.withColumn(
+            "body_parsed", f.from_json("body", body_schema)
+        ).select(
+            "*",
+            f.col("body_parsed.brand_id").alias("brand_id"),
+            f.col("body_parsed.total").alias("total"),
+        ).drop("body_parsed")
+        df_extracted.filter(f.col("brand_id").isNotNull()).select(
+            "order_id", "event_type", "brand_id", "total"
+        ).show(5, truncate=False)
+
+    return df_extracted
+
+
+def act3_recursive_cte(spark, orders_df):
+    """Step 3: Recursive CTE — traverse order event chains."""
+    section("STEP 3: Recursive CTE (Spark 4.1)")
+
+    print("""
+  Each order has a lifecycle: created → kitchen → ready → driver → delivered.
+  Events are linked by order_id + sequence number.
+  Recursive CTEs let us traverse this chain in SQL.
+    """)
+
+    orders_df.createOrReplaceTempView("order_events")
+
+    try:
+        chain_df = spark.sql("""
+            WITH RECURSIVE event_chain AS (
+                -- Anchor: start with order_created events (sequence 0)
+                SELECT order_id, event_id, event_type, event_timestamp, sequence,
+                       1 AS depth
+                FROM order_events
+                WHERE sequence = 0 AND event_type = 'order_created'
+
+                UNION ALL
+
+                -- Recursive: follow the chain by incrementing sequence
+                SELECT e.order_id, e.event_id, e.event_type, e.event_timestamp,
+                       e.sequence, c.depth + 1
+                FROM order_events e
+                JOIN event_chain c
+                  ON e.order_id = c.order_id
+                  AND e.sequence = c.sequence + 1
+            )
+            SELECT order_id, event_type, event_timestamp, depth
+            FROM event_chain
+            WHERE order_id IN (
+                SELECT DISTINCT order_id FROM order_events
+                WHERE sequence = 0 LIMIT 3
+            )
+            ORDER BY order_id, depth
+        """)
+
+        print("  Order lifecycle chains (via recursive CTE):")
+        chain_df.show(25, truncate=False)
+
+        print("  Before Spark 4.1: this required multiple self-joins or")
+        print("  collect() + Python iteration. Now it's one SQL query.")
+
+    except Exception as e:
+        print(f"  Recursive CTE not available: {e}")
+        print("  Falling back to sequential join approach...")
+        spark.sql("""
+            SELECT order_id, event_type, event_timestamp, sequence
+            FROM order_events
+            WHERE order_id IN (SELECT DISTINCT order_id FROM order_events LIMIT 3)
+            ORDER BY order_id, sequence
+        """).show(25, truncate=False)
+
+
+def act3_collation(spark):
+    """Step 4: Collation — case-insensitive search."""
+    section("STEP 4: Collation (Spark 4.1)")
+
+    print("""
+  A user asks: "Find all pizza brands."
+  Problem: brand names have mixed case — "Pizza Palace", "PIZZA Express", etc.
+  Old way: WHERE LOWER(name) LIKE '%pizza%'  (can't use index)
+  New way: WHERE name COLLATE utf8_lcase LIKE '%pizza%'  (collation-aware)
+    """)
+
+    try:
+        brands = spark.read.parquet("/data/dimensions/brands.parquet")
+        brands.createOrReplaceTempView("brands")
+
+        result = spark.sql("""
+            SELECT name, cuisine_type,
+                   name COLLATE utf8_lcase AS name_normalized
+            FROM brands
+            WHERE name COLLATE utf8_lcase LIKE '%burger%'
+               OR name COLLATE utf8_lcase LIKE '%pizza%'
+               OR name COLLATE utf8_lcase LIKE '%wok%'
+        """)
+
+        print("  Case-insensitive brand search (collation):")
+        result.show(truncate=False)
+
+    except Exception as e:
+        print(f"  Collation not available: {e}")
+        print("  Falling back to LOWER():")
+        brands = spark.read.parquet("/data/dimensions/brands.parquet")
+        brands.createOrReplaceTempView("brands")
+        spark.sql("""
+            SELECT name, cuisine_type
+            FROM brands
+            WHERE LOWER(name) LIKE '%burger%'
+               OR LOWER(name) LIKE '%pizza%'
+               OR LOWER(name) LIKE '%wok%'
+        """).show(truncate=False)
+
+
+def act3_spark_connect_intro():
+    """Step 5: Spark Connect — thin client introduction."""
+    section("STEP 5: Spark Connect (Preview)")
+
+    print("""
+  A user asks: "Do I need a full Spark install on my laptop?"
+
+  No. Spark Connect separates client from server.
+
+  SERVER (your cluster — already running):
+    /opt/spark/sbin/start-connect-server.sh --master spark://spark-master-41:7077
+    # Listens on port 15002 (gRPC + Arrow)
+
+  CLIENT (your laptop — 1.5 MB):
+    pip install pyspark-client  # No JVM required!
+
+    from pyspark.sql import SparkSession
+    spark = SparkSession.builder.remote("sc://cluster:15002").getOrCreate()
+    spark.sql("SELECT * FROM iceberg.bronze.orders").show()
+
+  Same DataFrame API. Same SQL. Zero JVM on client.
+  Protocol: gRPC for queries, Apache Arrow for results.
+
+  The progression:
+    Level 1: spark.master("local[*]")              # laptop, single JVM
+    Level 2: spark.master("spark://host:7078")      # standalone cluster
+    Level 3: spark.remote("sc://host:15002")        # thin client, remote cluster
+    Level 4: spark.remote("sc://k8s-lb:15002")      # thin client, K8s cluster
+
+  Your DataFrame code is IDENTICAL at every level.
+  Only the session builder changes.
+
+  We'll demo this fully in Act 5 (Enterprise Scaling).
+    """)
+
+
+def main():
+    spark = SparkSession.builder \
+        .appName("lakehouse-demo") \
+        .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("  WE NEED COMPUTE")
+    print("  Spark 4.1 — setup, config, and the new features.")
+    print("=" * 60)
+    print(f"  Spark version: {spark.version}")
+
+    # Load data first
+    try:
+        spark.read.parquet("/data/events/orders_90d.parquet").limit(1)
+    except Exception:
+        print("\n  ERROR: No test data found.")
+        print("  Run: ./lakehouse testdata generate --days 7 && ./lakehouse testdata load")
+        spark.stop()
+        return
+
+    act3_config_walkthrough(spark)
+
+    orders_df = act3_variant_type(spark)
+    act3_recursive_cte(spark, orders_df)
+    act3_collation(spark)
+    act3_spark_connect_intro()
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("  Next: we need PIPELINES to automate this.")
+    print("=" * 60 + "\n")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/spark_cluster_diagnostic.py
+++ b/scripts/demos/showcase/spark_cluster_diagnostic.py
@@ -72,7 +72,7 @@ def act3_config_walkthrough(spark):
                                                   /opt/spark/jars-extra/postgresql-*.jar
 
   A user asks: "That's... a lot of config."
-  Nick: "Welcome to open source."
+  User: "Welcome to open source."
 
   Key versions (don't change without testing):
     - Iceberg: 1.10.0

--- a/scripts/demos/showcase/spark_connect.py
+++ b/scripts/demos/showcase/spark_connect.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Spark Connect — Thin Client Progression
+================================================================
+
+Demonstrates the Spark Connect progression from laptop to enterprise.
+Same DataFrame code at every level — only the session builder changes.
+
+Four levels:
+  1. Local: SparkSession.builder.master("local[*]")
+  2. Standalone: SparkSession.builder.master("spark://host:7078")
+  3. Spark Connect: SparkSession.builder.remote("sc://host:15002")
+  4. K8s Connect: SparkSession.builder.remote("sc://k8s-lb:15002")
+
+Run (on the Spark cluster — demonstrates Level 2):
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        /scripts/demos/showcase/spark_connect.py
+
+Run (thin client from host — demonstrates Level 3):
+    # First, start Spark Connect server:
+    docker exec spark-master-41 /opt/spark/sbin/start-connect-server.sh \
+        --master spark://spark-master-41:7078 \
+        --packages org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0
+
+    # Then from your laptop (1.5 MB install):
+    pip install pyspark-client
+    python scripts/demos/showcase/spark_connect.py --remote sc://localhost:15002
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+import sys
+from pyspark.sql import SparkSession
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def get_spark_session():
+    """Create SparkSession based on CLI args or environment."""
+    remote_url = None
+    for i, arg in enumerate(sys.argv):
+        if arg == "--remote" and i + 1 < len(sys.argv):
+            remote_url = sys.argv[i + 1]
+
+    if remote_url:
+        print(f"  Mode: Spark Connect (thin client)")
+        print(f"  Remote: {remote_url}")
+        return SparkSession.builder \
+            .remote(remote_url) \
+            .getOrCreate()
+    else:
+        print(f"  Mode: Classic (driver on cluster)")
+        return SparkSession.builder \
+            .appName("lakehouse-demo") \
+            .getOrCreate()
+
+
+def act5b_connect_architecture():
+    """Step 1: How Spark Connect works."""
+    section("STEP 1: Spark Connect Architecture")
+
+    print("""
+  Traditional Spark (Classic Mode):
+    ┌─────────────────────────────────────────┐
+    │  Your Code + SparkSession + JVM Driver  │ ← Everything in one process
+    │  (PySpark uses Py4J to talk to JVM)     │
+    │         │                               │
+    │    Executors on workers                 │
+    └─────────────────────────────────────────┘
+
+  Spark Connect (Client-Server Mode):
+    ┌──────────────┐        ┌──────────────────────────┐
+    │  Your Laptop │  gRPC  │  SparkConnectServer      │
+    │  (Python)    │───────>│  (embedded in driver)    │
+    │  No JVM!     │<───────│                          │
+    │  1.5 MB      │ Arrow  │  Executors on workers    │
+    └──────────────┘        └──────────────────────────┘
+
+  Protocol:
+    Client → Server: gRPC + Protocol Buffers (query plan)
+    Server → Client: Apache Arrow (result data)
+
+  Port: 15002 (default)
+  Connection string: sc://host:15002/;option=value
+    """)
+
+
+def act5b_setup_commands():
+    """Step 2: How to set up Spark Connect."""
+    section("STEP 2: Setup Commands")
+
+    print("""
+  SERVER SIDE (on your Spark cluster):
+    # Start the Connect server (already included in Spark images)
+    /opt/spark/sbin/start-connect-server.sh \\
+        --master spark://spark-master-41:7078 \\
+        --jars /opt/spark/jars-extra/iceberg-spark-runtime-4.0_2.13-1.10.0.jar,\\
+               /opt/spark/jars-extra/aws-bundle-2.24.6.jar \\
+        --conf spark.sql.catalog.iceberg=org.apache.iceberg.spark.SparkCatalog \\
+        --conf spark.sql.catalog.iceberg.type=jdbc \\
+        --conf spark.sql.catalog.iceberg.uri=jdbc:postgresql://host:5432/iceberg_catalog
+
+    # Stop it
+    /opt/spark/sbin/stop-connect-server.sh
+
+  CLIENT SIDE (your laptop):
+    pip install pyspark-client    # 1.5 MB, no JVM required!
+    # Or: pip install pyspark     # Full install also works
+
+    python -c "
+    from pyspark.sql import SparkSession
+    spark = SparkSession.builder.remote('sc://localhost:15002').getOrCreate()
+    spark.sql('SELECT COUNT(*) FROM iceberg.bronze.orders').show()
+    "
+
+  THAT'S IT. Same API. No JVM on client.
+    """)
+
+
+def act5b_progression_demo(spark):
+    """Step 3: Run the same queries regardless of connection mode."""
+    section("STEP 3: The Same Code, Any Connection")
+
+    print(f"  Connected via: {'Spark Connect' if hasattr(spark, '_client') else 'Classic mode'}")
+    print(f"  Spark version: {spark.version}")
+
+    # The exact same DataFrame code works in all modes
+    print("\n  Query 1: Table row counts")
+    for table in ["iceberg.bronze.orders", "iceberg.bronze.dim_brands"]:
+        try:
+            count = spark.sql(f"SELECT COUNT(*) AS cnt FROM {table}").collect()[0][0]
+            print(f"    {table}: {count:,} rows")
+        except Exception as e:
+            print(f"    {table}: {e}")
+
+    print("\n  Query 2: Top 5 brands by order volume")
+    try:
+        spark.sql("""
+            SELECT b.name, COUNT(*) as order_count
+            FROM iceberg.bronze.orders o
+            JOIN iceberg.bronze.dim_brands b
+              ON CAST(
+                  get_json_object(o.body, '$.brand_id') AS INT
+              ) = b.id
+            WHERE o.event_type = 'order_created'
+              AND o.body IS NOT NULL
+            GROUP BY b.name
+            ORDER BY order_count DESC
+            LIMIT 5
+        """).show(truncate=False)
+    except Exception as e:
+        print(f"    Query failed: {e}")
+        print("    (This is expected if Iceberg tables aren't loaded)")
+
+    print("\n  Query 3: Hourly order distribution")
+    try:
+        spark.sql("""
+            SELECT HOUR(TO_TIMESTAMP(REPLACE(ts, 'T', ' '))) as hour,
+                   COUNT(*) as events
+            FROM iceberg.bronze.orders
+            WHERE event_type = 'order_created'
+            GROUP BY 1
+            ORDER BY 1
+        """).show(24, truncate=False)
+    except Exception as e:
+        print(f"    Query failed: {e}")
+
+    print("""
+  Key point: The queries above are IDENTICAL whether you're running:
+    - On the cluster (spark-submit)
+    - From your laptop via Spark Connect
+    - From a K8s pod via Spark Connect
+
+  Your code doesn't change. The infrastructure does.
+    """)
+
+
+def act5b_connect_vs_classic():
+    """Step 4: What you gain and lose with Spark Connect."""
+    section("STEP 4: Connect vs Classic — Tradeoffs")
+
+    print("""
+  WHAT YOU GAIN:
+    + No JVM on client (1.5 MB install vs 300+ MB)
+    + Language-native experience (pure Python, no Py4J)
+    + Client crashes don't kill the Spark application
+    + Multiple clients can share one Spark session/cluster
+    + Clean separation: laptop ↔ cluster
+
+  WHAT YOU LOSE:
+    - No RDD API (DataFrame/SQL only — you shouldn't be using RDDs anyway)
+    - No SparkContext access
+    - No direct JVM access (no df._jdf, no custom Catalyst rules)
+    - Security is bring-your-own (gRPC proxy for auth)
+    - Some edge-case APIs may not be available
+
+  WHAT STAYS THE SAME:
+    = DataFrame operations
+    = SQL queries
+    = Python UDFs
+    = Structured Streaming
+    = Catalog operations (SHOW TABLES, CREATE TABLE, etc.)
+    = ML (pyspark.ml — new in Spark 4.0)
+
+  For 95% of data engineering work: Spark Connect is strictly better.
+    """)
+
+
+def act5b_k8s_preview():
+    """Step 5: Preview of K8s deployment."""
+    section("STEP 5: K8s Deployment (Preview)")
+
+    print("""
+  The full progression (same code at every level):
+
+  ┌─────────────┬──────────────────────────────────────────────┐
+  │ Level       │ Session Builder                               │
+  ├─────────────┼──────────────────────────────────────────────┤
+  │ Laptop      │ .master("local[*]")                          │
+  │ Standalone  │ .master("spark://host:7078")                 │
+  │ Connect     │ .remote("sc://host:15002")                   │
+  │ K8s         │ .remote("sc://k8s-loadbalancer:15002")       │
+  └─────────────┴──────────────────────────────────────────────┘
+
+  K8s deployment:
+    1. Deploy SparkConnectServer as a K8s Deployment
+    2. Expose port 15002 via LoadBalancer Service
+    3. spark-submit --master k8s://https://api-server:6443 (server-side)
+    4. pip install pyspark-client (client-side)
+    5. SparkSession.builder.remote("sc://k8s-lb:15002")
+
+  For SDP on K8s:
+    spark-pipelines run --spec pipeline.yml \\
+        --master k8s://https://api-server:6443 \\
+        --conf spark.kubernetes.container.image=apache/spark:4.1.0 \\
+        --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark
+
+  Same pipeline. Same spec. Different master URL.
+  See 05c_spark_k8s.sh for full setup commands.
+    """)
+
+
+def main():
+    spark = get_spark_session()
+    try:
+        spark.sparkContext.setLogLevel("WARN")
+    except Exception:
+        pass  # Connect mode may not support setLogLevel
+
+    print("\n" + "=" * 60)
+    print("  SPARK CONNECT")
+    print("  Same code. Any connection. No JVM on client.")
+    print("=" * 60)
+
+    act5b_connect_architecture()
+    act5b_setup_commands()
+    act5b_progression_demo(spark)
+    act5b_connect_vs_classic()
+    act5b_k8s_preview()
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("  Next: we're lazy — let AI manage this.")
+    print("=" * 60 + "\n")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/spark_on_k8s.sh
+++ b/scripts/demos/showcase/spark_on_k8s.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Spark on Kubernetes Reference
+# =====================================================
+#
+# Reference commands for deploying Spark on K8s.
+# This is a reference script — run commands individually, not as a batch.
+#
+# Prerequisites:
+#   - minikube or kind installed
+#   - kubectl configured
+#   - Docker images available
+
+set -euo pipefail
+
+echo "============================================================"
+echo "  SPARK ON KUBERNETES"
+echo "  Same image. Same code. Different orchestrator."
+echo "============================================================"
+
+# ─── Step 1: Start minikube ─────────────────────────────────
+echo ""
+echo "--- Step 1: Start minikube (if not running) ---"
+echo ""
+echo "  minikube start --cpus 4 --memory 8192 --driver=docker"
+echo "  kubectl cluster-info"
+echo ""
+
+# ─── Step 2: Create RBAC for Spark ──────────────────────────
+echo "--- Step 2: RBAC Setup ---"
+echo ""
+cat <<'RBAC'
+  # Create service account
+  kubectl create serviceaccount spark -n default
+
+  # Grant permissions (pods, services, configmaps)
+  kubectl create clusterrolebinding spark-role \
+      --clusterrole=edit \
+      --serviceaccount=default:spark \
+      --namespace=default
+RBAC
+echo ""
+
+# ─── Step 3: Test with SparkPi ──────────────────────────────
+echo "--- Step 3: Test with SparkPi ---"
+echo ""
+cat <<'SPARKPI'
+  # Get the API server URL
+  API_SERVER=$(kubectl cluster-info | grep "control plane" | awk '{print $NF}')
+
+  # Submit SparkPi
+  spark-submit \
+      --master k8s://$API_SERVER \
+      --deploy-mode cluster \
+      --name spark-pi \
+      --conf spark.kubernetes.container.image=apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu \
+      --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
+      --conf spark.executor.instances=2 \
+      --conf spark.executor.memory=1g \
+      --conf spark.executor.cores=1 \
+      local:///opt/spark/examples/src/main/python/pi.py
+
+  # Watch pods spin up
+  kubectl get pods -w
+SPARKPI
+echo ""
+
+# ─── Step 4: Full Lakehouse on K8s ──────────────────────────
+echo "--- Step 4: Full Lakehouse Spark Job on K8s ---"
+echo ""
+cat <<'LAKEHOUSE'
+  # Custom image with JARs baked in (recommended for production)
+  # See: scripts/tools/build-spark-k8s-image.sh
+
+  # Or use remote JARs via S3:
+  spark-submit \
+      --master k8s://$API_SERVER \
+      --deploy-mode cluster \
+      --name lakehouse-pipeline \
+      --conf spark.kubernetes.container.image=apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu \
+      --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
+      --conf spark.kubernetes.namespace=spark-jobs \
+      --conf spark.executor.instances=3 \
+      --conf spark.executor.memory=4g \
+      --conf spark.executor.cores=2 \
+      --conf spark.sql.catalog.iceberg=org.apache.iceberg.spark.SparkCatalog \
+      --conf spark.sql.catalog.iceberg.catalog-impl=org.apache.iceberg.rest.RESTCatalog \
+      --conf spark.sql.catalog.iceberg.uri=http://unity-catalog-service:8080/api/2.1/unity-catalog/iceberg \
+      --conf spark.hadoop.fs.s3a.endpoint=http://seaweedfs-service:8333 \
+      --conf spark.hadoop.fs.s3a.access.key=${S3_ACCESS_KEY} \
+      --conf spark.hadoop.fs.s3a.secret.key=${S3_SECRET_KEY} \
+      --conf spark.hadoop.fs.s3a.path.style.access=true \
+      --jars local:///opt/spark/jars-extra/iceberg-spark-runtime-4.0_2.13-1.10.0.jar \
+      local:///scripts/pipelines/pipeline_spark41.py
+
+  # Key difference from standalone:
+  #   - --master k8s:// instead of spark://
+  #   - Services accessed via K8s DNS (unity-catalog-service, seaweedfs-service)
+  #   - Secrets via K8s Secrets, not .env file
+  #   - Executors are K8s pods, auto-cleaned after job
+LAKEHOUSE
+echo ""
+
+# ─── Step 5: SDP on K8s ─────────────────────────────────────
+echo "--- Step 5: SDP Pipeline on K8s ---"
+echo ""
+cat <<'SDP_K8S'
+  # spark-pipelines wraps spark-submit, so K8s just works:
+  spark-pipelines run \
+      --spec /scripts/pipelines/spark-pipeline.yml \
+      --master k8s://$API_SERVER \
+      --deploy-mode cluster \
+      --conf spark.kubernetes.container.image=apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu \
+      --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark
+
+  # Same pipeline spec. Same Python code. Different orchestrator.
+SDP_K8S
+echo ""
+
+# ─── Step 6: Spark Connect on K8s ───────────────────────────
+echo "--- Step 6: Spark Connect Server on K8s ---"
+echo ""
+cat <<'CONNECT_K8S'
+  # Deploy Connect server as a K8s Deployment
+  kubectl apply -f - <<EOF
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: spark-connect-server
+    namespace: spark-jobs
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: spark-connect
+    template:
+      metadata:
+        labels:
+          app: spark-connect
+      spec:
+        serviceAccountName: spark
+        containers:
+        - name: spark-connect
+          image: apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu
+          command: ["/opt/spark/sbin/start-connect-server.sh", "--wait"]
+          ports:
+          - containerPort: 15002
+            name: grpc
+          env:
+          - name: SPARK_MASTER
+            value: "k8s://https://kubernetes.default.svc:443"
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: spark-connect
+    namespace: spark-jobs
+  spec:
+    type: LoadBalancer
+    ports:
+    - port: 15002
+      targetPort: 15002
+    selector:
+      app: spark-connect
+  EOF
+
+  # From your laptop:
+  pip install pyspark-client
+  python -c "
+  from pyspark.sql import SparkSession
+  spark = SparkSession.builder.remote('sc://k8s-lb:15002').getOrCreate()
+  spark.sql('SHOW TABLES IN iceberg.bronze').show()
+  "
+CONNECT_K8S
+echo ""
+
+# ─── Summary ────────────────────────────────────────────────
+echo "--- Summary: Standalone vs K8s ---"
+echo ""
+cat <<'SUMMARY'
+  ┌──────────────┬─────────────────────────────────┬─────────────────────────────────┐
+  │ Aspect       │ Standalone (docker-compose)      │ Kubernetes                      │
+  ├──────────────┼─────────────────────────────────┼─────────────────────────────────┤
+  │ Master URL   │ spark://localhost:7078           │ k8s://https://api-server:6443   │
+  │ Workers      │ Static in compose file           │ Dynamic pods, autoscaling       │
+  │ Config       │ Volume mounts (spark-defaults)   │ ConfigMaps or baked in image    │
+  │ JARs         │ Volume mounts (./jars)           │ Baked in image or remote S3     │
+  │ Secrets      │ .env file                        │ K8s Secrets                     │
+  │ Monitoring   │ localhost:8082                   │ kubectl port-forward            │
+  │ Scaling      │ Manual                           │ Dynamic allocation              │
+  │ Code changes │ NONE                             │ NONE                            │
+  └──────────────┴─────────────────────────────────┴─────────────────────────────────┘
+
+  Same image. Same code. Same pipeline. Different orchestrator.
+SUMMARY
+echo ""
+echo "============================================================"
+echo "  Done."
+echo "============================================================"

--- a/scripts/demos/showcase/streaming_udtf.py
+++ b/scripts/demos/showcase/streaming_udtf.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Streaming + Python UDTF
+================================================
+
+Demonstrates:
+1. Kafka → Spark Structured Streaming → Iceberg (batch mode for demo)
+2. Python UDTF to explode order lifecycle into event rows
+
+Run:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        --packages org.apache.spark:spark-sql-kafka-0-10_2.13:4.1.0 \
+        /scripts/demos/showcase/streaming_udtf.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse testdata generate --days 1
+    ./lakehouse testdata load
+    # Optional: python -m scripts.testdata --kafka (to produce to Kafka)
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as f
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType, TimestampType
+
+def main():
+    spark = SparkSession.builder \
+        .appName("lakehouse-demo") \
+        .config("spark.sql.streaming.schemaInference", "true") \
+        .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("Streaming + Python UDTF")
+    print("=" * 60)
+    print(f"Spark version: {spark.version}")
+
+    # Part A: Use batch orders as source (streaming requires Kafka producer)
+    # For live demo: switch to readStream.format("kafka") when producer is running
+    try:
+        orders_df = spark.read.parquet("/data/events/orders_90d.parquet").limit(500)
+    except Exception:
+        # Create minimal sample
+        from pyspark.sql.types import StructType, StructField
+        schema = StructType([
+            StructField("event_id", StringType()),
+            StructField("event_type", StringType()),
+            StructField("ts", StringType()),
+            StructField("order_id", StringType()),
+            StructField("location_id", IntegerType()),
+            StructField("sequence", IntegerType()),
+            StructField("body", StringType()),
+        ])
+        sample = [
+            ("e1", "order_created", "2024-01-15T12:00:00", "ORD001", 1, 0, '{"brand_id":1,"total":25.99}'),
+            ("e2", "delivered", "2024-01-15T12:45:00", "ORD001", 1, 7, '{"total_mins":45.0}'),
+        ]
+        orders_df = spark.createDataFrame(sample * 100, schema)
+
+    orders_df = orders_df.withColumn(
+        "event_timestamp", f.to_timestamp(f.regexp_replace("ts", "T", " "))
+    )
+
+    # Build order_lifecycle (pivot) - need silver.order_lifecycle or create from orders
+    # For demo: create minimal lifecycle from orders
+    from pyspark.sql.types import StructType, StructField, IntegerType, DoubleType
+    body_schema = StructType([
+        StructField("brand_id", IntegerType(), True),
+        StructField("total", DoubleType(), True),
+    ])
+    enriched = orders_df.withColumn("body_parsed", f.from_json("body", body_schema)).select(
+        "order_id", "event_type", "event_timestamp", "location_id",
+        f.col("body_parsed.total").alias("order_total"),
+    )
+
+    # Pivot to get created_at, delivered_at per order
+    lifecycle = enriched.groupBy("order_id", "location_id").pivot(
+        "event_type", ["order_created", "delivered"]
+    ).agg(f.min("event_timestamp").alias("ts"))
+
+    lifecycle = lifecycle.select(
+        "order_id",
+        f.col("order_created").alias("created_at"),
+        f.col("delivered").alias("delivered_at"),
+        "location_id",
+        f.lit("San Francisco").alias("city_name"),
+    ).filter(f.col("delivered_at").isNotNull())
+
+    # Ensure we have data
+    if lifecycle.count() == 0:
+        # Create synthetic lifecycle
+        from datetime import datetime, timedelta
+        base = datetime(2024, 1, 15, 12, 0, 0)
+        rows = [
+            (f"ORD{i:03d}", base + timedelta(minutes=i), base + timedelta(minutes=i+45), 1, "San Francisco")
+            for i in range(20)
+        ]
+        lifecycle = spark.createDataFrame(rows, ["order_id", "created_at", "delivered_at", "location_id", "city_name"])
+
+    lifecycle.createOrReplaceTempView("order_lifecycle")
+
+    # Part B: Python UDTF - explode order into event rows
+    from pyspark.sql.functions import udtf
+
+    from pyspark.sql.types import StructType, StructField, StringType, TimestampType, DoubleType, IntegerType as IT
+
+    @udtf(returnType=StructType([
+        StructField("order_id", StringType()),
+        StructField("event_type", StringType()),
+        StructField("event_ts", TimestampType()),
+        StructField("duration_mins", DoubleType()),
+        StructField("location_id", IT()),
+        StructField("city_name", StringType()),
+    ]))
+    class OrderLifecycleExploder:
+        def eval(self, order_id: str, created_at, delivered_at, location_id: int, city_name: str):
+            if created_at is None:
+                return
+            total_mins = (delivered_at - created_at).total_seconds() / 60 if delivered_at else None
+            yield (order_id, "order_created", created_at, None, location_id, city_name)
+            if delivered_at:
+                yield (order_id, "delivered", delivered_at, total_mins, location_id, city_name)
+
+    spark.udtf.register("order_lifecycle_explode", OrderLifecycleExploder)
+
+    print("\n[UDTF] Registered order_lifecycle_explode()")
+    print("  Invoking: SELECT * FROM order_lifecycle_explode(SELECT ... FROM order_lifecycle)")
+
+    # Spark 4.1: UDTF with table argument
+    try:
+        exploded = spark.sql("""
+            SELECT * FROM order_lifecycle_explode(
+                TABLE order_lifecycle
+            )
+        """)
+    except Exception:
+        # Fallback: call row-by-row via lateral join or collect
+        try:
+            exploded = spark.sql("""
+                SELECT o.order_id, o.created_at, o.delivered_at, o.location_id, o.city_name
+                FROM order_lifecycle o
+                LIMIT 10
+            """)
+            # Simulate explode: create two rows per order
+            from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType
+            rows = []
+            for row in exploded.collect():
+                rows.append((row.order_id, "order_created", row.created_at, None, row.location_id, row.city_name))
+                if row.delivered_at:
+                    mins = (row.delivered_at - row.created_at).total_seconds() / 60
+                    rows.append((row.order_id, "delivered", row.delivered_at, mins, row.location_id, row.city_name))
+            exploded = spark.createDataFrame(rows, ["order_id", "event_type", "event_ts", "duration_mins", "location_id", "city_name"])
+            print("  [FALLBACK] Simulated UDTF output (TABLE syntax not supported)")
+        except Exception as e:
+            print(f"  [SKIP] UDTF not available: {e}")
+            exploded = lifecycle.limit(5)
+
+    print("\n  Exploded order lifecycle (sample):")
+    exploded.show(15, truncate=False)
+
+    # Write to Iceberg
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.overarch")
+    exploded.write.mode("overwrite").saveAsTable("iceberg.gold.order_events_exploded")
+    print("\n[Iceberg] Created iceberg.gold.order_events_exploded")
+
+    print("\n" + "=" * 60)
+    print("Demo 2 complete!")
+    print("=" * 60)
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demos/showcase/streaming_udtf.py
+++ b/scripts/demos/showcase/streaming_udtf.py
@@ -159,7 +159,7 @@ def main():
     exploded.show(15, truncate=False)
 
     # Write to Iceberg
-    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.overarch")
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.gold")
     exploded.write.mode("overwrite").saveAsTable("iceberg.gold.order_events_exploded")
     print("\n[Iceberg] Created iceberg.gold.order_events_exploded")
 

--- a/scripts/demos/showcase/unity_catalog_setup.py
+++ b/scripts/demos/showcase/unity_catalog_setup.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+"We Need a Catalog" — Unity Catalog OSS
+===============================================================
+
+They need a catalog.
+Unity Catalog OSS provides: REST catalog, credential vending, multi-engine interop.
+
+Demonstrates:
+  1. UC REST API — list catalogs, schemas, tables
+  2. Register Iceberg tables via REST catalog
+  3. Credential vending — UC gates access to object storage
+  4. Multi-engine interop — same table from Spark AND DuckDB-compatible clients
+  5. Catalog-managed commits (experimental)
+  6. Honest gaps — what OSS UC doesn't have (yet)
+
+Run:
+    # Start UC first:
+    ./lakehouse start unity-catalog
+
+    # Then run this script against Spark configured for UC:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        --conf spark.sql.catalog.unity=org.apache.iceberg.spark.SparkCatalog \
+        --conf spark.sql.catalog.unity.catalog-impl=org.apache.iceberg.rest.RESTCatalog \
+        --conf spark.sql.catalog.unity.uri=http://localhost:8081/api/2.1/unity-catalog/iceberg \
+        /scripts/demos/showcase/unity_catalog_setup.py
+
+    # Or use the UC spark config:
+    docker exec spark-master-41 /opt/spark/bin/spark-submit \
+        --properties-file /opt/spark/conf/spark-defaults-uc.conf \
+        /scripts/demos/showcase/unity_catalog_setup.py
+
+Prerequisites:
+    ./lakehouse start all
+    ./lakehouse start unity-catalog
+    ./lakehouse testdata generate --days 7
+    ./lakehouse testdata load
+"""
+
+from pyspark.sql import SparkSession
+import json
+
+# UC REST API base URL (default port)
+UC_BASE_URL = "http://localhost:8081"
+UC_API = f"{UC_BASE_URL}/api/2.1/unity-catalog"
+UC_ICEBERG_API = f"{UC_BASE_URL}/api/2.1/unity-catalog/iceberg"
+
+
+def section(title):
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def uc_rest_call(endpoint, method="GET", data=None):
+    """Make a REST call to Unity Catalog API. Returns dict or None on error."""
+    import urllib.request
+    import urllib.error
+
+    url = f"{UC_API}/{endpoint}"
+    try:
+        req = urllib.request.Request(url, method=method)
+        req.add_header("Content-Type", "application/json")
+        if data:
+            req.data = json.dumps(data).encode("utf-8")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.URLError as e:
+        return {"error": str(e)}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def act2_check_connectivity():
+    """Step 0: Is UC running?"""
+    section("STEP 0: Check Unity Catalog Connectivity")
+
+    result = uc_rest_call("catalogs")
+    if "error" in result:
+        print(f"  UC not reachable at {UC_BASE_URL}")
+        print(f"  Error: {result['error']}")
+        print(f"  Run: ./lakehouse start unity-catalog")
+        return False
+
+    catalogs = result.get("catalogs", [])
+    print(f"  UC is running at {UC_BASE_URL}")
+    print(f"  Catalogs found: {len(catalogs)}")
+    for cat in catalogs:
+        print(f"    - {cat.get('name', 'unknown')}")
+    return True
+
+
+def act2_setup_steps():
+    """Step 1: How many steps to set up UC? Show the answer."""
+    section("STEP 1: Unity Catalog Setup (How Hard Is It?)")
+
+    print("""
+  A user asks: "How hard is this to set up?"
+
+  Three commands:
+
+    1. Start the server:
+       docker compose -f docker-compose-unity-catalog.yml up -d
+
+    2. Verify it's running:
+       curl http://localhost:8081/api/2.1/unity-catalog/catalogs
+
+    3. Point Spark at it:
+       spark.sql.catalog.iceberg.catalog-impl = org.apache.iceberg.rest.RESTCatalog
+       spark.sql.catalog.iceberg.uri = http://localhost:8081/api/2.1/unity-catalog/iceberg
+
+  That's it. A default catalog called 'unity' ships out of the box.
+  No database migrations. No config files. No cloud account.
+    """)
+
+
+def act2_explore_catalog(spark):
+    """Step 2: Explore what's in the catalog via REST + Spark SQL."""
+    section("STEP 2: Explore the Catalog")
+
+    # REST API exploration
+    print("  Via REST API:")
+    catalogs = uc_rest_call("catalogs")
+    if "catalogs" in catalogs:
+        for cat in catalogs["catalogs"]:
+            cat_name = cat.get("name", "unknown")
+            print(f"\n  Catalog: {cat_name}")
+
+            schemas = uc_rest_call(f"schemas?catalog_name={cat_name}")
+            if "schemas" in schemas:
+                for schema in schemas["schemas"]:
+                    schema_name = schema.get("name", "unknown")
+                    print(f"    Schema: {schema_name}")
+
+                    tables = uc_rest_call(
+                        f"tables?catalog_name={cat_name}&schema_name={schema_name}"
+                    )
+                    if "tables" in tables:
+                        for tbl in tables["tables"]:
+                            tbl_name = tbl.get("name", "unknown")
+                            tbl_type = tbl.get("table_type", "unknown")
+                            data_format = tbl.get("data_source_format", "unknown")
+                            print(f"      Table: {tbl_name} ({tbl_type}, {data_format})")
+
+    # Spark SQL exploration (if UC catalog is configured)
+    print("\n  Via Spark SQL:")
+    try:
+        spark.sql("SHOW NAMESPACES IN unity").show(truncate=False)
+    except Exception as e:
+        print(f"    Spark not configured for UC catalog 'unity': {e}")
+        print("    This is expected if running with default JDBC catalog config.")
+        print("    To use UC: pass --properties-file /opt/spark/conf/spark-defaults-uc.conf")
+
+
+def act2_register_tables(spark):
+    """Step 3: Register tables in UC."""
+    section("STEP 3: Register Tables in Unity Catalog")
+
+    print("""
+  Two ways to register tables in UC:
+
+  A) REST API — programmatic, any language:
+     POST /api/2.1/unity-catalog/tables
+     {"name": "orders", "catalog_name": "unity", "schema_name": "bronze",
+      "table_type": "EXTERNAL", "data_source_format": "ICEBERG",
+      "storage_location": "s3://lakehouse/warehouse/bronze/orders"}
+
+  B) Spark SQL — if Spark is configured with UC as catalog:
+     CREATE TABLE unity.bronze.orders USING iceberg
+     LOCATION 's3://lakehouse/warehouse/bronze/orders'
+    """)
+
+    # Try registering via REST
+    print("  Registering schemas via REST API...")
+
+    # Create bronze schema if not exists
+    for schema_name in ["bronze", "silver", "gold"]:
+        result = uc_rest_call("schemas", method="POST", data={
+            "name": schema_name,
+            "catalog_name": "unity",
+            "comment": f"Medallion {schema_name} layer — Casper's Kitchen data",
+        })
+        if "error" in result:
+            # Schema may already exist
+            print(f"    {schema_name}: already exists or error")
+        else:
+            print(f"    {schema_name}: created")
+
+
+def act2_credential_vending():
+    """Step 4: Credential vending — UC gates storage access."""
+    section("STEP 4: Credential Vending")
+
+    print("""
+  A user asks: "How do we control who accesses the raw files?"
+
+  Unity Catalog credential vending (overhauled in v0.4.0):
+
+  NEW in 0.4.0 — two-layer credential model:
+    1. Storage Credentials: define HOW to access storage (IAM role, keys)
+       POST /api/2.1/unity-catalog/credentials
+       {"name": "seaweedfs-creds", "aws_iam_role": {...}}
+
+    2. External Locations: define WHERE storage is + bind to credentials
+       POST /api/2.1/unity-catalog/external-locations
+       {"name": "lakehouse-data", "url": "s3://lakehouse/warehouse",
+        "credential_name": "seaweedfs-creds"}
+
+  The flow:
+    - Client requests access to a table
+    - UC validates via external location matching
+    - UC returns short-lived, scoped storage credentials
+    - Client uses those credentials to read/write data
+    - Credentials expire — no permanent keys floating around
+
+  How it works with Iceberg REST Catalog:
+    1. Client calls GET /v1/namespaces/bronze/tables/orders
+    2. Response includes temporary S3 credentials
+    3. Client reads parquet files using those credentials
+    4. No direct S3 access needed — UC is the gatekeeper
+
+  In our setup (SeaweedFS):
+    - UC vends S3-compatible credentials for SeaweedFS
+    - Same protocol as AWS S3, Azure ADLS, or GCS
+    - Credential rotation is automatic
+    - AWS IAM role support added in 0.4.0
+    """)
+
+    # Show the Iceberg REST catalog endpoint
+    print("  Iceberg REST Catalog endpoint:")
+    print(f"    {UC_ICEBERG_API}")
+    print("    This is what Spark, DuckDB, Trino, etc. all connect to.")
+    print("    One endpoint, many engines, credential vending built in.")
+
+
+def act2_multi_engine():
+    """Step 5: Multi-engine interop — the killer feature."""
+    section("STEP 5: Multi-Engine Interop (The Killer Feature)")
+
+    print("""
+  A user asks: "Can DuckDB read our tables too?"
+
+  YES. That's the whole point of the Iceberg REST Catalog protocol.
+
+  From Spark:
+    spark.sql("SELECT * FROM unity.bronze.orders LIMIT 5")
+
+  From DuckDB:
+    INSTALL iceberg;
+    LOAD iceberg;
+    ATTACH 'http://localhost:8081/api/2.1/unity-catalog/iceberg'
+      AS unity (TYPE ICEBERG);
+    SELECT * FROM unity.bronze.orders LIMIT 5;
+
+  From Trino:
+    connector.name=iceberg
+    iceberg.catalog.type=rest
+    iceberg.rest-catalog.uri=http://localhost:8081/api/2.1/unity-catalog/iceberg
+
+  From Polars:
+    import polars as pl
+    df = pl.scan_iceberg(
+        "unity.bronze.orders",
+        storage_options={"uri": "http://localhost:8081/..."}
+    )
+
+  Same table. Same data. Same catalog. Different engines.
+  This is what open standards buy you.
+    """)
+
+
+def act2_catalog_managed_commits():
+    """Step 6: Catalog-managed commits (experimental)."""
+    section("STEP 6: Catalog-Managed Commits (Experimental)")
+
+    print("""
+  A user asks: "What if Spark and DuckDB write at the same time?"
+
+  Catalog-managed commits (flagship feature in UC 0.4.0):
+    - UC server centrally coordinates table commits
+    - Multiple engines can safely write to the same table
+    - No commit conflicts — UC is the single authority
+    - Enabled via: server.managed-table.enabled=true
+
+  The protocol (Delta tables):
+    1. Client calls POST /staging-tables (UC assigns storage path)
+    2. Client writes data + delta log
+    3. Client calls POST /tables to finalize
+    4. Subsequent writes: staged commits → POST /delta/preview/commits to ratify
+    5. Reads combine published + ratified commits
+
+  For Iceberg tables via REST Catalog:
+    - The REST catalog protocol inherently coordinates commits
+    - The catalog server IS the commit authority
+    - This is baked into the Iceberg REST spec — not a UC-specific hack
+
+  UniForm (NEW in 0.4.0):
+    - Delta commits can atomically update Iceberg metadata
+    - Write as Delta, read as Iceberg — transparent to downstream engines
+
+  Status: Production-ready for Delta. Iceberg REST reads solid.
+  Multi-writer scenarios: test thoroughly.
+    """)
+
+
+def act2_honest_gaps():
+    """Step 7: What UC OSS does NOT have."""
+    section("STEP 7: The Honest Gaps")
+
+    print("""
+  A user asks: "So this is just like Databricks Unity Catalog?"
+
+  No. Here's what OSS UC 0.4.0 gives you:
+    [x] Iceberg REST Catalog (strong, production-ready)
+    [x] Credential vending via external locations (overhauled in 0.4.0)
+    [x] Storage credentials API with IAM role support
+    [x] Multi-engine interop (Spark, DuckDB, Trino, etc.)
+    [x] Catalog-managed commits (Delta — flagship 0.4.0 feature)
+    [x] Managed storage locations for catalogs/schemas
+    [x] UniForm (Delta-to-Iceberg atomic metadata)
+    [x] Authorization framework (OAuth + grants)
+    [x] Schema/table/volume management
+    [x] Model registry (MLflow integration)
+    [x] Helm charts for K8s deployment
+
+  Here's what it does NOT have (roadmapped for v0.5+):
+    [ ] Full RBAC with row-level filters / column masks
+    [ ] Audit logging
+    [ ] Data lineage
+    [ ] Delta Sharing
+    [ ] Lakehouse Federation
+    [ ] Group management / service principals
+    [ ] Native Iceberg writes (only Delta-via-UniForm)
+    [ ] Multi-tenancy
+
+  The honest take:
+    UC OSS 0.4.0 is a real catalog with credential vending,
+    managed commits, and multi-engine interop. It's come a
+    long way from 0.1. But full governance (RBAC, audit,
+    lineage) is still in the future.
+
+  That's not a failure — that's the reality of open source vs managed.
+  You get a solid foundation. The rest is yours to build or buy.
+    """)
+
+
+def main():
+    spark = SparkSession.builder \
+        .appName("lakehouse-demo") \
+        .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    print("\n" + "=" * 60)
+    print("  WE NEED A CATALOG")
+    print("  Unity Catalog OSS — open, extensible, honest.")
+    print("=" * 60)
+    print(f"  Spark version: {spark.version}")
+
+    # Check connectivity first
+    uc_available = act2_check_connectivity()
+
+    # Always show the setup steps (works without UC running)
+    act2_setup_steps()
+
+    if uc_available:
+        act2_explore_catalog(spark)
+        act2_register_tables(spark)
+
+    # These sections are informational — work without UC running
+    act2_credential_vending()
+    act2_multi_engine()
+    act2_catalog_managed_commits()
+    act2_honest_gaps()
+
+    print("\n" + "=" * 60)
+    print("  Done.")
+    print("  Next: we need COMPUTE to process this data.")
+    print("=" * 60 + "\n")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demo_suites.py
+++ b/tests/test_demo_suites.py
@@ -1,0 +1,91 @@
+"""Regression tests for the demo suites added in PR #43.
+
+Lightweight checks that don't require a live Spark cluster: every demo
+parses as valid Python, no show-era framing leaked through, and the
+READMEs exist.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SHOWCASE = PROJECT_ROOT / "scripts" / "demos" / "showcase"
+AGENTS = PROJECT_ROOT / "scripts" / "demos" / "mlflow-agents"
+
+
+class TestDemoSuitesPresent:
+    """Both new demo directories exist with READMEs."""
+
+    def test_showcase_dir_has_readme(self):
+        assert (SHOWCASE / "README.md").is_file()
+
+    def test_mlflow_agents_dir_has_readme(self):
+        assert (AGENTS / "README.md").is_file()
+
+    def test_top_level_demos_readme_indexes_suites(self):
+        readme = (PROJECT_ROOT / "scripts" / "demos" / "README.md").read_text()
+        assert "showcase/" in readme
+        assert "mlflow-agents/" in readme
+
+
+@pytest.mark.parametrize(
+    "py_file",
+    sorted(SHOWCASE.glob("*.py")) + sorted(AGENTS.glob("*.py")),
+    ids=lambda p: str(p.relative_to(PROJECT_ROOT)),
+)
+def test_demo_parses(py_file):
+    """Each demo script must be importable Python — even if it can't
+    execute without a live cluster, it should at least parse."""
+    ast.parse(py_file.read_text())
+
+
+@pytest.mark.parametrize(
+    "demo_dir",
+    [SHOWCASE, AGENTS],
+    ids=lambda p: p.name,
+)
+def test_no_show_framing_leaked(demo_dir):
+    """sed-stripped in Phase 3 — guard against regressions. Holly and Nick
+    are the original show hosts; OverArchitected was the episode title."""
+    forbidden = ("OverArchitected", "Holly", "Nick", "smuggled out")
+    for py_file in demo_dir.glob("*.py"):
+        text = py_file.read_text()
+        for term in forbidden:
+            assert term not in text, (
+                f"{py_file.name} still contains show framing: '{term}'"
+            )
+
+
+class TestShowcaseBuildingBlocks:
+    """Each named building block from the PR description should exist."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "otf_portability.py",
+            "iceberg_variant.py",
+            "unity_catalog_setup.py",
+            "spark41_feature_tour.py",
+            "spark_cluster_diagnostic.py",
+            "streaming_udtf.py",
+            "sdp_showcase.py",
+            "sdp_demo.py",
+            "realtime_mode.py",
+            "airflow_sdp.py",
+            "spark_connect.py",
+            "spark_on_k8s.sh",
+            "sdp-pipeline.yml",
+        ],
+    )
+    def test_building_block_exists(self, filename):
+        assert (SHOWCASE / filename).is_file()
+
+
+class TestMlflowAgents:
+    """Three named agents: guardian, analyst, autopilot."""
+
+    @pytest.mark.parametrize("name", ["guardian", "analyst", "autopilot"])
+    def test_agent_exists(self, name):
+        assert (AGENTS / f"{name}.py").is_file()


### PR DESCRIPTION
## Summary
Brings the useful OverArchitected demo scripts forward under a neutral home (`scripts/demos/showcase/` and `scripts/demos/mlflow-agents/`), stripped of show framing (Holly/Nick dialogue, "OverArchitected Act N" titles, "headline demo" framing, branded appNames/namespaces).

**Base:** `feat/forward-stack-infra` (PR #42). This PR stacks on top of that and will rebase cleanly onto develop once #42 merges.

## What's included

**`scripts/demos/showcase/`** — 13 one-script-per-component demos:
- `otf_portability.py` — reading Iceberg/Parquet data outside any managed platform (was `01_data_smuggled.py`)
- `iceberg_variant.py` — Spark 4.1 VARIANT over Iceberg
- `unity_catalog_setup.py` — end-to-end UC OSS bootstrap + multi-client access
- `spark41_feature_tour.py` — VARIANT + recursive CTE + collation + SDP + Iceberg
- `spark_cluster_diagnostic.py` — cluster introspection tour
- `streaming_udtf.py` — Python UDTFs on a streaming DataFrame
- `sdp_showcase.py` — imperative vs declarative side-by-side
- `sdp_demo.py` + `sdp-pipeline.yml` — clean medallion pipeline
- `realtime_mode.py` — Structured Streaming Real-Time Mode
- `airflow_sdp.py` — Airflow DAG patterns for SDP
- `spark_connect.py` — remote Spark driver
- `spark_on_k8s.sh` — K8s submit

**`scripts/demos/mlflow-agents/`** — three reference agents on MLflow AI Gateway + Tracing + Model Registry: `guardian`, `analyst`, `autopilot`

**`scripts/demos/README.md`** — top-level index pointing to the three demo suites (showcase, mlflow-agents, SDP walkthrough)

## What's dropped
- `scripts/demos/overarchitected/live/*.sh` — show runbooks (live teleprompter driven)
- `scripts/demos/overarchitected/run_e2e_test.sh` — show e2e runner
- `00_sdp_showcase.py` — near-dupe of `04a_sdp_showcase.py` (kept newer)
- `docs/guides/overarchitected/*.md` — companion guides (archived to obsidian)
- `docs/OVERARCHITECTED_SHOW.md`, `docs/SHOW_PREP.md` (archived)

## Show framing stripped
- "OverArchitected Act/Demo N: " prefixes in docstrings + print banners
- "Holly and Nick quit Databricks..." opener, "Holly asks:" / "Nick asks:" dialogue → `A user asks:`
- "THE headline demo.", "CO-HEADLINER", `Part of the "..." act.`
- `appName("OverArchitected-...")` → `appName("lakehouse-demo")`
- `iceberg.overarch.*` namespace → `iceberg.gold.*`
- Path references updated from `scripts/demos/overarchitected/<old>.py` to new locations

## Test plan
- [ ] `grep -r "overarchitected\|Holly\|Nick" scripts/demos/showcase scripts/demos/mlflow-agents` returns empty (verified locally)
- [ ] Running any showcase script via `./lakehouse start all` + `spark-submit` works end to end
- [ ] MLflow agents import cleanly against `mlflow>=3.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)