### PR TITLE
chore: upgrade notebooks JupyterLab image to Spark 4.1

### DIFF
--- a/docker-compose-notebooks.yml
+++ b/docker-compose-notebooks.yml
@@ -1,18 +1,25 @@
-# Jupyter Lab for running workshop notebooks
+# JupyterLab for running workshop notebooks against Spark 4.1.
+#
+# Builds a local image (docker/jupyter/Dockerfile) that layers JupyterLab
+# on top of apache/spark:4.1.0 so the Spark runtime inside the notebook
+# matches the rest of the stack (SDP, VARIANT, Real-Time Mode, etc.).
 #
 # Usage:
-#   docker compose -f docker-compose-notebooks.yml up -d
+#   docker compose -f docker-compose-notebooks.yml up -d --build
 #   # Open http://localhost:8889 (no token required)
 #   docker compose -f docker-compose-notebooks.yml down
 #
-# Notes:
-# - Notebooks run Spark in local mode for learning/demonstration
-# - For cluster execution, use the standalone scripts via spark-submit:
-#   docker exec spark-master-41 spark-submit /scripts/pipelines/pipeline_spark41.py
+# Notebooks run Spark in local mode. For cluster execution, submit to
+# spark-master-41:
+#   docker exec spark-master-41 /opt/spark/bin/spark-submit \
+#     /scripts/pipelines/pipeline_spark41.py
 
 services:
   jupyter:
-    image: jupyter/pyspark-notebook:spark-3.5.0
+    build:
+      context: .
+      dockerfile: docker/jupyter/Dockerfile
+    image: lakehouse-jupyter:spark-4.1.0
     container_name: jupyter
     network_mode: "host"
     user: root
@@ -21,15 +28,4 @@ services:
       - ./scripts:/home/jovyan/scripts
       - ./data:/home/jovyan/data
       - ./jars:/home/jovyan/jars
-    environment:
-      - JUPYTER_ENABLE_LAB=yes
-      - JUPYTER_PORT=8889
-      - GRANT_SUDO=yes
-      - NB_USER=jovyan
-      # Use Spark's bundled version (3.5.0) in local mode for notebooks
-      - SPARK_HOME=/usr/local/spark
-      - PYTHONPATH=/usr/local/spark/python:/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip
     working_dir: /home/jovyan/notebooks
-    command: >
-      bash -c "pip install pyarrow --quiet &&
-               start-notebook.py --NotebookApp.token='' --NotebookApp.password='' --allow-root"

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -6,17 +6,26 @@ FROM apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu
 USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3-pip \
+      python3-pip python3-venv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir --break-system-packages \
+# Use a venv to sidestep PEP 668 on newer Ubuntu base images (and to avoid
+# clobbering the base image's system-site-packages). Pin pip first so the
+# jupyterlab resolver has a modern version.
+ENV VIRTUAL_ENV=/opt/jupyter-venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install --no-cache-dir --upgrade "pip>=24.0" setuptools wheel
+RUN pip install --no-cache-dir \
       jupyterlab==4.3.0 \
       ipykernel==6.29.5 \
       pyspark==4.1.0 \
       pandas==2.2.3 \
       pyarrow==18.1.0 \
-      matplotlib==3.9.2
+      matplotlib==3.9.2 \
+      "httpx<0.28"   # jupyterlab 4.3 uses httpx AsyncClient(proxies=...) removed in 0.28
 
 ENV JUPYTER_ENABLE_LAB=yes \
     PYSPARK_PYTHON=python3 \

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,0 +1,35 @@
+# JupyterLab on Apache Spark 4.1 (Python 3, Java 21)
+# Matches the Spark 4.1 runtime used by the rest of the stack so notebooks
+# can execute pyspark 4.1 features (SDP, VARIANT, RTM, etc.) in local mode.
+FROM apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir --break-system-packages \
+      jupyterlab==4.3.0 \
+      ipykernel==6.29.5 \
+      pyspark==4.1.0 \
+      pandas==2.2.3 \
+      pyarrow==18.1.0 \
+      matplotlib==3.9.2
+
+ENV JUPYTER_ENABLE_LAB=yes \
+    PYSPARK_PYTHON=python3 \
+    PYSPARK_DRIVER_PYTHON=python3
+
+WORKDIR /home/jovyan
+EXPOSE 8889
+
+CMD ["jupyter", "lab", \
+     "--ip=0.0.0.0", \
+     "--port=8889", \
+     "--no-browser", \
+     "--allow-root", \
+     "--ServerApp.token=", \
+     "--ServerApp.password=", \
+     "--ServerApp.disable_check_xsrf=True"]


### PR DESCRIPTION
## Summary
- Add `docker/jupyter/Dockerfile` layering JupyterLab on `apache/spark:4.1.0-scala2.13-java21-python3-r-ubuntu`
- Update `docker-compose-notebooks.yml` to build and run that image

## Why
The old compose used `jupyter/pyspark-notebook:spark-3.5.0`, but the two tracked workshop notebooks (`notebooks/spark40_imperative_pipeline.ipynb`, `notebooks/spark41_declarative_pipeline.ipynb`) assume Spark 4.x features — SDP decorators, `VARIANT`, Real-Time Mode. Running them in the 3.5 image silently fails on those cells. Upstream `jupyter/pyspark-notebook` has not released a Spark 4.x tag, so this PR bakes our own image.

**Base:** `feat/forward-stack-infra` (PR #42). Stack this cleanly on top of it; rebases onto develop once #42 lands.

**Out of scope for this PR (flagged for later):** compose files use a mix of `network_mode: host` and a `lakehouse-network` bridge — standardizing that needs end-to-end testing on all services, deferring to its own PR.

## Test plan
- [ ] `docker compose -f docker-compose-notebooks.yml up -d --build` produces a running container on `:8889`
- [ ] `spark41_declarative_pipeline.ipynb` runs the SDP cells without `AttributeError` on `pyspark.pipelines`
- [ ] `spark40_imperative_pipeline.ipynb` still runs (pyspark 4.x is backwards-compatible with imperative patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)