### PR TITLE
docs: position as composable OSS reference architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Self-hostable data lakehouse: Spark 4.x + Iceberg 1.10 + Kafka 3.6 + PostgreSQL + SeaweedFS.
+Composable OSS lakehouse reference architecture. Spark 4.x + (Iceberg 1.10 **and** Delta 4.0) + Kafka 3.6 + PostgreSQL + SeaweedFS + Unity Catalog OSS 0.4.0 + MLflow 3.1 + Airflow 3.1. Runs locally on Docker, deploys to AWS via Terraform. See `README.md` for positioning and roadmap (Apache Ozone, Kubernetes).
 
 ## Documentation
 
@@ -92,38 +92,51 @@ poetry run pytest -m spark41 -v                           # Spark 4.1 only
 | `docker-compose.yml` | Spark 4.0 cluster |
 | `docker-compose-kafka.yml` | Kafka + Zookeeper |
 | `docker-compose-unity-catalog.yml` | Unity Catalog OSS server |
+| `docker-compose-mlflow.yml` | MLflow tracking + AI Gateway |
 | `docker-compose-airflow.yml` | Apache Airflow orchestration |
-| `dags/` | Airflow DAG definitions |
-| `jars/` | Required JARs (~860MB) |
-| `scripts/quickstarts/` | Tutorials (01-04) and demos |
+| `docker-compose-notebooks.yml` | JupyterLab (Spark 4.1 via `docker/jupyter/Dockerfile`) |
+| `config/mlflow/gateway-config.yml` | MLflow AI Gateway routes (Anthropic + Ollama) |
+| `config/spark/spark-defaults-{uc,delta}.conf.example` | Spark config for UC / Delta |
+| `dags/` | Airflow DAG definitions (incl. `sdp_pipeline.py`) |
+| `jars/` | Required JARs (~860MB, gitignored) |
+| `scripts/quickstarts/` | Tutorials (01-04) |
 | `scripts/connectivity/` | Integration test scripts (run via CLI) |
 | `scripts/pipelines/` | Spark pipeline scripts (SDP, Spark 4.0/4.1) |
-| `scripts/demos/` | Interactive demo scripts |
-| `scripts/tools/` | Utility scripts (download-jars, etc) |
+| `scripts/demos/showcase/` | One-script-per-stack-component demos |
+| `scripts/demos/mlflow-agents/` | MLflow AI Gateway reference agents |
+| `scripts/demos/transformations/` | SDP walkthrough pipelines |
+| `scripts/tools/` | Utility scripts (download-jars, worktree, etc.) |
 | `scripts/testdata/` | Test data generator |
-| `tests/` | Test suite |
+| `benchmarks/` | Runnable perf harness (file/table formats, workloads) |
+| `tests/` | Test suite (`integration/sdp/` is SDP-specific) |
 | `schemas/` | Database migrations |
-| `terraform/` | AWS infrastructure |
+| `terraform/` | AWS self-hosted deployment |
+| `terraform-databricks/` | Databricks managed destination |
+| `AGENTS.md` | Spark 4.1 reference for AI assistants |
 | `.pre-commit-config.yaml` | Security hooks |
 
 ## Architecture
 
 ```
-Spark 4.x → Iceberg 1.10 → PostgreSQL (metadata) + SeaweedFS (data)
-                ↑               ↑
-            Kafka 3.6      Unity Catalog (optional REST catalog)
-                ↑
-            Airflow (optional orchestration)
+Spark 4.x  →  Iceberg 1.10 / Delta 4.0 (dual-OTF)  →  Catalog  →  SeaweedFS (S3 API)
+     ↑                                                   ↑
+   Kafka 3.6                            PostgreSQL JDBC  |  Unity Catalog OSS (0.4.0)
+     ↑
+   Airflow 3.1                          MLflow 3.1 + AI Gateway (Anthropic + Ollama)
 ```
 
 **Catalog Options:**
 - **PostgreSQL JDBC** (default) - Direct SQL, Spark-only
-- **Unity Catalog OSS** (optional) - REST API, multi-client (DuckDB, Trino, etc.)
+- **Unity Catalog OSS** (optional) - REST API, multi-client (DuckDB, Trino, etc.), 0.4.0 catalog-managed commits
+
+**OTF Options (mix freely):**
+- **Iceberg** for the default bronze/silver/gold path
+- **Delta** runs on the same cluster via `config/spark/spark-defaults-delta.conf.example`
 
 **Namespaces (Medallion):**
-- `iceberg.bronze.*` - Raw data
-- `iceberg.silver.*` - Cleaned
-- `iceberg.gold.*` - Aggregated
+- `iceberg.bronze.*` / `delta.bronze.*` - Raw
+- `iceberg.silver.*` / `delta.silver.*` - Cleaned
+- `iceberg.gold.*` / `delta.gold.*` - Aggregated
 
 ## Ports
 
@@ -137,6 +150,9 @@ Spark 4.x → Iceberg 1.10 → PostgreSQL (metadata) + SeaweedFS (data)
 | Zookeeper | 2181 |
 | Unity Catalog | 8081 (when running with Spark) |
 | Airflow | 8085 |
+| MLflow Tracking | 5000 |
+| MLflow AI Gateway | 5001 |
+| JupyterLab (optional) | 8889 |
 
 ## Code Style
 
@@ -239,13 +255,13 @@ See `docs/DEV_WORKFLOW.md` for full workflow details.
 
 ## AI Skills Reference
 
-The `.claude/skills/` directory contains detailed reference guides for AI assistants:
+Two top-level references for AI assistants:
 
-| Skill File | Topic |
-|------------|-------|
-| `SDP.md` | Spark Declarative Pipelines - complete reference from basics to production |
+| File | Topic |
+|------|-------|
+| `AGENTS.md` | Compressed Spark 4.1 reference (always in context, no skill invocation) |
+| `.claude/skills/SDP.md` | Spark Declarative Pipelines — full reference, patterns, common errors |
 
-**When to use skills files:**
-- When writing Spark pipelines, read `.claude/skills/SDP.md` first
-- Skills files contain patterns, common errors, and lakehouse-specific examples
-- They are tested with AI assistants to ensure clarity and completeness
+**When to use:**
+- `AGENTS.md` is compact enough to load up-front — read it before writing any PySpark
+- `.claude/skills/SDP.md` is deeper — read before designing or debugging an SDP pipeline

--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
 # Lakehouse at Home
 
-A fully open-source, self-hostable data lakehouse for local development and testing of modern data workflows. Run production-grade infrastructure on your laptop with Apache Spark, Iceberg, and Kafka - no cloud account required. Includes a realistic data generation framework to test batch and streaming pipelines.
+A composable open-source reference architecture for a Databricks-equivalent data lakehouse. Everything runs locally on Docker, scales to AWS via Terraform, and is deliberately made up of swappable parts — Iceberg **and** Delta, Unity Catalog **or** PostgreSQL JDBC, SeaweedFS today **and** Apache Ozone tomorrow.
 
 [![CI](https://github.com/lisancao/lakehouse-at-home/actions/workflows/ci.yml/badge.svg)](https://github.com/lisancao/lakehouse-at-home/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![GitHub stars](https://img.shields.io/github/stars/lisancao/lakehouse-at-home)](https://github.com/lisancao/lakehouse-at-home/stargazers)
 [![Spark](https://img.shields.io/badge/Spark-4.0%20%7C%204.1-E25A1C?logo=apachespark&logoColor=white)](https://spark.apache.org/)
 [![Iceberg](https://img.shields.io/badge/Iceberg-1.10-blue)](https://iceberg.apache.org/)
+[![Delta](https://img.shields.io/badge/Delta-4.0-00ADD4)](https://delta.io/)
+[![Unity Catalog](https://img.shields.io/badge/Unity%20Catalog-0.4.0-FF3621)](https://www.unitycatalog.io/)
+[![MLflow](https://img.shields.io/badge/MLflow-3.1-0194E2?logo=mlflow)](https://mlflow.org/)
 
-**Why Lakehouse at Home?**
-- **Learn** data engineering with real tools, not toy examples
-- **Develop** and test Spark jobs locally before deploying to production
-- **Experiment** with Iceberg table formats, streaming pipelines, and medallion architecture
-- **Deploy** (optional) to your cloud provider when ready using included Terraform templates
+## Why this exists
+
+Most "run Spark locally" projects stop at a single-node Spark + a Parquet file. Most Databricks tutorials stop at the Databricks boundary. This repo sits in the middle: a **composable OSS stack** that exposes the same primitives Databricks gives you — open table formats, a governance catalog, declarative pipelines, orchestration, ML lifecycle — assembled from upstream Apache projects so you can:
+
+- **Learn** the lakehouse paradigm on tools that will still exist without any one vendor
+- **Prototype** pipelines that will run identically on EMR, Databricks, or any Kubernetes cluster
+- **Benchmark** different combinations (Iceberg vs Delta, UC vs JDBC catalog, micro-batch vs RTM)
+- **Migrate** data in or out — Iceberg/Delta metadata is portable by design
 
 ## Stack
 
-| Component | Version | Purpose |
-|-----------|---------|---------|
-| Apache Spark | 4.0 / 4.1 | Distributed compute |
-| Apache Iceberg | 1.10 | ACID table format |
-| Apache Kafka | 3.6 | Event streaming |
-| Apache Airflow | 3.1 | Workflow orchestration |
-| PostgreSQL | 16 | Catalog metadata |
-| SeaweedFS | - | S3-compatible storage |
-| Unity Catalog | 0.3.1 | REST catalog (optional) |
+| Layer | Component | Version | Alternatives on this stack |
+|-------|-----------|---------|----------------------------|
+| Compute | Apache Spark | 4.0 / 4.1 | Spark 3.5 via compose variant |
+| Table format | Apache Iceberg | 1.10 | Delta Lake 4.0 side-by-side |
+| Streaming | Apache Kafka | 3.6 | Direct-to-Spark via Structured Streaming |
+| Orchestration | Apache Airflow | 3.1 | SparkSubmitOperator DAGs in `dags/` |
+| Catalog | Unity Catalog OSS | 0.4.0 | PostgreSQL JDBC catalog |
+| ML lifecycle | MLflow + AI Gateway | 3.1 | Anthropic + Ollama configured out of the box |
+| Metadata DB | PostgreSQL | 16 | Managed RDS in AWS terraform |
+| Object store | SeaweedFS | latest | S3 in AWS, Apache Ozone on the roadmap |
+
+Every component ships with an example config (`config/spark/spark-defaults-{uc,delta}.conf.example`) and a compose file (`docker-compose-*.yml`). Turn individual services on and off via the `lakehouse` CLI.
 
 ## Requirements
 
@@ -34,242 +42,203 @@ A fully open-source, self-hostable data lakehouse for local development and test
 | Disk | 20 GB | 50 GB |
 | CPU | 4 cores | 8 cores |
 
-**Software**: Docker, Java 17+ (21 for Spark 4.1), Python 3.10+, Poetry
+**Software**: Docker, Java 17+ (21 for Spark 4.1), Python 3.10+, Poetry 2.1+
 
-## Getting Started
+## Getting started
 
-### AI-Assisted Setup
+```bash
+git clone https://github.com/lisancao/lakehouse-at-home.git
+cd lakehouse-at-home
 
-Using Claude Code, Cursor, or another AI coding assistant? Point it at this repo:
+./lakehouse setup            # validate prereqs, download JARs, install deps
+nano .env                    # credentials
+nano config/spark/spark-defaults.conf
+
+./lakehouse start all        # Spark + Kafka + Postgres + SeaweedFS
+./lakehouse test             # connectivity checks
+```
+
+Optional services:
+
+```bash
+./lakehouse start unity-catalog   # UC OSS 0.4.0 on :8081
+./lakehouse start airflow         # Airflow 3.1 on :8085
+./lakehouse start mlflow          # MLflow + AI Gateway
+```
+
+See [docs/getting-started/installation.md](docs/getting-started/installation.md) for OS-specific setup and [docs/guides/cli-reference.md](docs/guides/cli-reference.md) for all CLI commands.
+
+### AI-assisted setup
+
+If you're using Claude Code, Cursor, or a similar agent:
 
 ```
 Clone https://github.com/lisancao/lakehouse-at-home and follow CLAUDE.md to set up locally.
 ```
 
-The agent will use `CLAUDE.md` for context and `./lakehouse setup` to validate prerequisites.
+The agent will read `CLAUDE.md` and `AGENTS.md` (a compressed Spark 4.1 reference) for context.
 
-### Manual Setup
+## Demos
 
-```bash
-# Clone
-git clone https://github.com/lisancao/lakehouse-at-home.git
-cd lakehouse-at-home
+`scripts/demos/` contains three progressively deeper suites:
 
-# Setup (validates prereqs, downloads JARs, installs deps)
-./lakehouse setup
+| Suite | What you get |
+|-------|--------------|
+| [`showcase/`](scripts/demos/showcase/README.md) | 13 one-script-per-component demos — OTF portability, VARIANT, UC bootstrap, SDP, Real-Time Mode, Airflow, Spark Connect, Spark on K8s |
+| [`mlflow-agents/`](scripts/demos/mlflow-agents/README.md) | Three reference MLflow agents (guardian, analyst, autopilot) that manage the lakehouse using the AI Gateway + Tracing + Model Registry |
+| [`transformations/` + root](scripts/demos/README.md) | 5-minute Spark Declarative Pipelines walkthrough with voiceover |
 
-# Configure credentials
-nano .env
-nano config/spark/spark-defaults.conf
+Benchmarks live under [`benchmarks/`](benchmarks/) — a runnable harness across file formats (CSV/Parquet/ORC/JSON), table formats (Iceberg/Delta), and workloads (UDF, Kafka, Iceberg).
 
-# Start
-./lakehouse start all
-
-# Verify
-./lakehouse test
-```
-
-See [Installation Guide](docs/getting-started/installation.md) for detailed OS-specific setup.
-
-## CLI
+## Test data
 
 ```bash
-# Setup & validation
-./lakehouse setup                # Validate prereqs, download JARs, install deps
-./lakehouse check-config         # Validate credential consistency
-./lakehouse preflight            # Test service connectivity
-
-# Service management
-./lakehouse start all            # Start Spark + Kafka
-./lakehouse stop all             # Stop all services
-./lakehouse status               # Check service health
-./lakehouse status --json        # Machine-readable status
-./lakehouse test                 # Run connectivity tests
-./lakehouse logs spark-master    # View logs
-
-# Unity Catalog (optional)
-./lakehouse start unity-catalog  # Start Unity Catalog REST server
-./lakehouse stop unity-catalog   # Stop Unity Catalog
-
-# Airflow (optional)
-./lakehouse start airflow        # Start Airflow scheduler + webserver
-./lakehouse stop airflow         # Stop Airflow
-./lakehouse logs airflow-webserver  # View Airflow logs
+./lakehouse testdata generate --days 7    # ghost-kitchen order data
+./lakehouse testdata load                 # load to Iceberg
+./lakehouse testdata stream --speed 60    # replay to Kafka at 60×
 ```
 
-See [CLI Reference](docs/guides/cli-reference.md) for all commands.
+See [docs/guides/test-data.md](docs/guides/test-data.md).
 
-## Test Data
+## Architecture
 
-Generate realistic order data for testing:
+```
+┌───────────────────────────────────────────────────────────────────────────────────┐
+│                          QUERIES / DASHBOARDS / AGENTS                            │
+│     Spark SQL · Time Travel · Reports · MLflow-served agents (Guardian/Analyst)   │
+└───────────────────────────────────────────────────────────────────────────────────┘
+                                         ▲
+                                         │
+┌─────────────────────┐    ┌───────────────────────────────────────────────────────┐
+│  STREAMING          │    │                   COMPUTE: Spark 4.x                  │
+│  Kafka  :9092       │───▶│  ┌─────────┐  ┌─────────┐  ┌─────────┐                │
+│  Zookeeper :2181    │    │  │ BRONZE  │─▶│ SILVER  │─▶│  GOLD   │   SDP + RTM   │
+└─────────────────────┘    │  └─────────┘  └─────────┘  └─────────┘                │
+                           │  Spark 4.0 :7077  UI :8080                            │
+┌─────────────────────┐    │  Spark 4.1 :7078  UI :8082                            │
+│  ORCHESTRATION      │───▶└──────────────────┬───────────────────┬────────────────┘
+│  Airflow :8085      │                       │                   │
+│  DAGs → SparkSubmit │                       │ Iceberg API       │ Delta API
+└─────────────────────┘                       │                   │
+                                              ▼                   ▼
+┌─────────────────────┐                ┌─────────────────────────────────────────┐
+│  ML LIFECYCLE       │                │        CATALOG (pick one or both)        │
+│  MLflow Tracking    │───────────────▶│  Unity Catalog  :8081 │ PostgreSQL :5432 │
+│  AI Gateway         │   model ref    │  REST, multi-engine  │ JDBC, Spark-only │
+│  Anthropic + Ollama │                └──────────────────────┬──────────────────┘
+└─────────────────────┘                                       │
+                                                              ▼
+                                ┌──────────────────────────────────────────────┐
+                                │        STORAGE (S3-compatible)                │
+                                │   SeaweedFS :8333   →   Apache Ozone (future) │
+                                │   s3://lakehouse/warehouse/{bronze,silver,gold}│
+                                └──────────────────────────────────────────────┘
+```
+
+**Dual-OTF by design.** Iceberg and Delta run against the same Spark cluster and the same object store. Pick one per table or run both; UC speaks Iceberg REST, Spark speaks both natively.
+
+**Catalog options.**
+
+| | PostgreSQL JDBC | Unity Catalog OSS |
+|--|---|---|
+| Protocol | Direct SQL | REST |
+| Clients | Spark only | Spark, DuckDB, Trino, Dremio |
+| Governance | Coarse (DB ACLs) | Fine-grained, credential vending |
+| Setup | Simpler | More flexible |
+
+## Ports
+
+| Service | Port | UI |
+|---------|------|----|
+| PostgreSQL | 5432 | - |
+| SeaweedFS | 8333 | - |
+| Spark 4.0 master | 7077 | http://localhost:8080 |
+| Spark 4.1 master | 7078 | http://localhost:8082 |
+| Kafka | 9092 | - |
+| Zookeeper | 2181 | - |
+| Unity Catalog | 8081 | REST API |
+| Airflow | 8085 | http://localhost:8085 |
+| MLflow Tracking | 5000 | http://localhost:5000 |
+| MLflow AI Gateway | 5001 | http://localhost:5001 |
+| JupyterLab (optional) | 8889 | http://localhost:8889 |
+
+## Cloud deployment
 
 ```bash
-./lakehouse testdata generate --days 7    # Generate 7 days
-./lakehouse testdata load                 # Load to Iceberg
-./lakehouse testdata stream --speed 60    # Stream to Kafka
+# AWS: VPC + S3 + RDS + optional EMR
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+terraform init && terraform apply
 ```
 
-See [Test Data Guide](docs/guides/test-data.md) for details.
+See [docs/deployment/aws.md](docs/deployment/aws.md) | Estimated: $50–500/month
+
+```bash
+# Databricks (if you want a managed destination for the same Iceberg tables)
+cd terraform-databricks
+cp terraform.tfvars.example terraform.tfvars
+terraform init && terraform apply
+```
+
+See [docs/deployment/databricks.md](docs/deployment/databricks.md) | Estimated: $100–800/month
+
+## Testing
+
+```bash
+poetry install --with dev,test
+
+poetry run pytest tests/ -v                             # everything
+poetry run pytest tests/ --ignore=tests/integration/    # unit only
+poetry run pytest tests/integration/ -v                 # integration
+poetry run pytest -m sdp -v                             # SDP suite
+poetry run pytest -m security -v                        # security
+./scripts/connectivity/test-spark-versions.sh -v 4.0 -v 4.1 -t all
+```
 
 ## Documentation
 
 | Guide | Description |
 |-------|-------------|
 | [Quickstart](docs/getting-started/quickstart.md) | 5-minute setup |
-| [Installation](docs/getting-started/installation.md) | macOS, Ubuntu, Windows guides |
-| [Configuration](docs/getting-started/configuration.md) | Environment and Spark config |
+| [Installation](docs/getting-started/installation.md) | macOS, Ubuntu, Windows |
+| [Configuration](docs/getting-started/configuration.md) | Env + Spark config |
 | [CLI Reference](docs/guides/cli-reference.md) | All commands |
-| [Streaming](docs/guides/streaming.md) | Kafka + Spark streaming |
-| [Airflow](docs/guides/airflow.md) | Workflow orchestration |
+| [Streaming](docs/guides/streaming.md) | Kafka + Structured Streaming |
+| [SDP data sources](docs/guides/sdp-data-sources.md) | Spark Declarative Pipelines compatibility matrix |
+| [Airflow](docs/guides/airflow.md) | Orchestration patterns |
 | [Multi-Version Spark](docs/guides/multi-version.md) | Run 4.0 and 4.1 together |
-| [Unity Catalog](docs/guides/unity-catalog.md) | REST catalog setup & migration |
-| [Architecture](docs/architecture.md) | System design |
-| [AWS Deployment](docs/deployment/aws.md) | Cloud production setup |
-| [Databricks Deployment](docs/deployment/databricks.md) | Managed Spark platform |
+| [Unity Catalog](docs/guides/unity-catalog.md) | UC OSS setup & migration |
+| [Architecture](docs/architecture.md) | Detailed system design |
+| [AWS Deployment](docs/deployment/aws.md) | EMR + S3 + RDS |
+| [Databricks Deployment](docs/deployment/databricks.md) | Managed destination |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues |
-| [Security](SECURITY.md) | Security guidelines for contributors |
-| [AI Skills](https://github.com/lisancao/lakehouse-skills) | AI assistant references (SDP, etc.) |
+| [Security](SECURITY.md) | Contributor guidelines |
+| [AGENTS.md](AGENTS.md) | Spark 4.1 reference for AI coding assistants |
 
-## Architecture
+## Roadmap
 
-```
-┌───────────────────────────────────────────────────────────────────────────────────┐
-│                                    QUERIES                                        │
-│            Spark SQL  •  Time Travel  •  Dashboards  •  Reports                   │
-└───────────────────────────────────────────────────────────────────────────────────┘
-                                        ▲
-                                        │
-┌──────────────────────┐    ┌───────────────────────────────────────────────────────┐
-│                      │    │                    COMPUTE: Spark 4.x                 │
-│  STREAMING           │    │                                                       │
-│                      │    │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐   │
-│  Kafka (:9092)       │───▶│  │   BRONZE    │─▶│   SILVER    │─▶│    GOLD     │   │
-│  └─ events topic     │    │  │ (raw ingest)│  │  (cleaned)  │  │ (aggregated)│   │
-│  └─ orders topic     │    │  └─────────────┘  └─────────────┘  └─────────────┘   │
-│                      │    │                                                       │
-│  Zookeeper (:2181)   │    │  Spark 4.0 (:7077, UI :8080)                         │
-│                      │    │  Spark 4.1 (:7078, UI :8082)                         │
-│  (direct to Spark,   │    └───────────────────────────────────────────┬──────────┘
-│   not via catalog)   │                        ▲                       │
-└──────────────────────┘                        │                       │ Iceberg API
-                                                │ docker exec           │
-┌──────────────────────┐                        │ spark-submit          │
-│  ORCHESTRATION       │────────────────────────┘                       │
-│                      │                                                │
-│  Airflow (:8085)     │  (Airflow schedules Spark jobs;                │
-│  └─ DAGs             │   Spark talks to Iceberg)                      │
-│  └─ Sensors          │                                                │
-└──────────────────────┘                                                │
-                                                                        ▼
-                            ┌───────────────────────────────────────────────────────┐
-                            │                 CATALOG: Iceberg Metadata             │
-                            │                                                       │
-                            │  PostgreSQL (:5432)          Unity Catalog (:8080)    │
-                            │  └─ JDBC catalog             └─ REST catalog          │
-                            │  └─ table schemas            └─ multi-engine access   │
-                            │  └─ snapshots, partitions                             │
-                            └──────────────────────────┬────────────────────────────┘
-                                                       │
-                                                       ▼
-                            ┌───────────────────────────────────────────────────────┐
-                            │               STORAGE: SeaweedFS (S3 API)             │
-                            │                                                       │
-                            │  s3://lakehouse/warehouse/                            │
-                            │  ├── bronze/*.parquet                                 │
-                            │  ├── silver/*.parquet                                 │
-                            │  └── gold/*.parquet                                   │
-                            │                                                       │
-                            │  :8333 (S3-compatible object storage)                 │
-                            └───────────────────────────────────────────────────────┘
-```
-
-**How It Works:**
-1. **Streaming** → Kafka feeds events directly to Spark (not via catalog)
-2. **Compute** → Spark transforms data through Bronze → Silver → Gold layers
-3. **Orchestration** → Airflow schedules Spark jobs via `docker exec spark-submit`
-4. **Catalog** → PostgreSQL or Unity Catalog manages Iceberg table metadata
-5. **Storage** → SeaweedFS stores Parquet files accessed via Iceberg
-
-**Catalog Options:**
-| Feature | PostgreSQL JDBC | Unity Catalog |
-|---------|-----------------|---------------|
-| Protocol | Direct SQL | REST API |
-| Clients | Spark only | Spark, DuckDB, Trino, Dremio |
-| Auth | Database credentials | OAuth / Token |
-| Setup | Simpler | More flexible |
-
-## Ports
-
-| Service | Port | UI |
-|---------|------|-----|
-| PostgreSQL | 5432 | - |
-| SeaweedFS | 8333 | - |
-| Spark 4.0 | 7077 | http://localhost:8080 |
-| Spark 4.1 | 7078 | http://localhost:8082 |
-| Kafka | 9092 | - |
-| Airflow | 8085 | http://localhost:8085 |
-| Unity Catalog | 8080 | REST API |
-
-## Cloud Deployment
-
-### AWS (EMR + S3 + RDS)
-
-```bash
-cd terraform
-cp terraform.tfvars.example terraform.tfvars
-terraform init && terraform apply
-```
-
-See [AWS Deployment Guide](docs/deployment/aws.md) | Estimated: $50-500/month
-
-### Databricks
-
-```bash
-cd terraform-databricks
-cp terraform.tfvars.example terraform.tfvars
-terraform init && terraform apply
-```
-
-See [Databricks Deployment Guide](docs/deployment/databricks.md) | Estimated: $100-800/month
-
-## Testing
-
-```bash
-# Install test dependencies
-poetry install --with dev,test
-
-# Run all tests
-poetry run pytest tests/ -v
-
-# Run specific test categories
-poetry run pytest tests/ --ignore=tests/integration/  # Unit tests
-poetry run pytest tests/integration/ -v               # Integration tests
-poetry run pytest -m security -v                      # Security tests
-
-# Multi-version Spark testing
-./scripts/connectivity/test-spark-versions.sh -v 4.0 -v 4.1 -t all
-```
+- **Apache Ozone** as an S3-compatible object store alternative to SeaweedFS (stronger consistency, larger-scale deployments)
+- **Kubernetes** deployment path (Helm charts + the existing `spark_on_k8s.sh` demo as the starting point)
+- **Trino / DuckDB** query engines wired into Unity Catalog for multi-engine access
+- **Dagster** as an alternative orchestrator alongside Airflow
+- **Apache Polaris** as a UC alternative catalog
+- **OpenLineage** across the whole stack for lineage tracking
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for security guidelines.
-
 ```bash
-# Install pre-commit hooks
 pre-commit install
-
-# Run security checks
 pre-commit run --all-files
 poetry run pytest -m security -v
 ```
 
+See [SECURITY.md](SECURITY.md).
+
 ## Contributing
 
-Contributions welcome! Please:
-1. Open an issue first to discuss changes
-2. Install pre-commit hooks: `pre-commit install`
-3. Run tests before submitting: `poetry run pytest tests/`
-4. See [SECURITY.md](SECURITY.md) for security requirements
+1. Open an issue first to discuss non-trivial changes
+2. Work off `develop` (CI/CD expects `feat/* → develop → master`)
+3. Install pre-commit hooks and run tests before pushing
 
 ## License
 


### PR DESCRIPTION
## Summary
Rewrites README and CLAUDE to frame the repo as a composable OSS reference architecture instead of a hobby "run-Spark-at-home" kit. Picks up all the stack evolution from PR #42 (MLflow, Delta, UC 0.4.0, port 8081) and PR #43 (showcase + mlflow-agents demos) so new visitors land on an accurate picture.

**Base:** `feat/forward-stack-infra` (PR #42). Siblings: PR #43 (demos), PR #44 (notebooks image).

## Key changes
- **Opening paragraph**: reference architecture positioning, explicit "Iceberg **and** Delta" composability, future Apache Ozone
- **Stack table**: Delta Lake 4.0, Unity Catalog OSS 0.4.0, MLflow 3.1 + AI Gateway, alternatives column
- **Architecture diagram**: dual-OTF, MLflow agents querying the gold layer, UC vs PostgreSQL JDBC, Ozone on the object-store axis
- **Demos section**: points at the three suites (showcase, mlflow-agents, SDP walkthrough)
- **Roadmap section**: Apache Ozone, Kubernetes, Trino/DuckDB, Dagster, Apache Polaris, OpenLineage
- **Ports table**: corrects UC to 8081, adds MLflow Tracking/Gateway/JupyterLab
- **CLAUDE.md**: updated key files (MLflow, new demo dirs, AGENTS.md, benchmarks/, terraform-databricks/), architecture block, AI skills section

## Test plan
- [ ] Visit the rendered README on GitHub after merge — stack table and diagram render
- [ ] All relative links resolve (`scripts/demos/showcase/README.md`, etc.)
- [ ] `AGENTS.md` link in getting-started section points at the committed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)