### PR TITLE
ci: gate PRs and pushes to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, develop]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, develop]
 
 # Security: Restrict default permissions
 permissions:


### PR DESCRIPTION
## Summary
Add `develop` to both the `push` and `pull_request` trigger branches in `.github/workflows/ci.yml`. Two-line change.

## Why
Our flow is `feat/* → develop → master`, but CI only triggered on PRs to `master`/`main`. PRs targeting `develop` (the integration branch) merged without any automated checks. This is the gap that lets regressions reach develop before master ever sees them.

## Test plan
- [ ] After merge, push to `develop` triggers CI
- [ ] PRs opened against `develop` show check runs
- [ ] Existing `master`/`main` triggers still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)