### PR TITLE
chore(macos): add GNU coreutils check + use gdf (credit Denis Arnaud)

### DIFF
--- a/lakehouse
+++ b/lakehouse
@@ -23,13 +23,12 @@ NC='\033[0m' # No Color
 # See also https://github.com/cloud-helpers/k8s-job-wrappers/tree/main/setGnuTools.sh
 export DF_TOOL="df"
 check_gnutools_on_macos() {
-	DF_TOOL="gdf"
-	if [ ! $(command -v $DF_TOOL) ]
-	then
+    DF_TOOL="gdf"
+    if [ ! "$(command -v "$DF_TOOL")" ]; then
         echo -e "${RED}Missing GNU tools on MacOS:${NC}"
         echo -e "  ${RED}✗${NC} $DF_TOOL"
-		return 1
-	fi
+        return 1
+    fi
 }
 
 # Check if a command exists
@@ -1140,17 +1139,17 @@ cmd_setup() {
     local has_errors=0
 
     # Step 1.1: Check for GNU tools, when on MacOS
-	if [ -f /usr/bin/sw_vers ]
-	then	
-		echo -e "\n${YELLOW}1.1. Checking for GNU tools when on MacOS...${NC}"
-		if ! check_gnutools_on_macos; then
-			echo -e "\n${RED}Please install GNU tools on MacOS before continuing.${NC}"
-			echo "See SETUP.md for installation instructions."
-			has_errors=1
-		else
-			echo -e "${GREEN}✓ All required tools installed when on MacOS${NC}"
-		fi
-	fi
+    if [ -f /usr/bin/sw_vers ]; then
+        echo -e "\n${YELLOW}1.1. Checking for GNU tools when on MacOS...${NC}"
+        if ! check_gnutools_on_macos; then
+            echo -e "\n${RED}Please install GNU coreutils on MacOS before continuing.${NC}"
+            echo "  brew install coreutils"
+            echo "See docs/getting-started/installation.md for details."
+            has_errors=1
+        else
+            echo -e "${GREEN}✓ All required tools installed when on MacOS${NC}"
+        fi
+    fi
 
     # Step 1.2: Check prerequisites
     echo -e "\n${YELLOW}1.2. Checking prerequisites...${NC}"

--- a/lakehouse
+++ b/lakehouse
@@ -1258,7 +1258,7 @@ cmd_setup() {
 
     # Step 7: Check disk space
     echo -e "\n${YELLOW}6. Checking disk space...${NC}"
-    local free_gb=$(gdf -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
+    local free_gb=$($DF_TOOL -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
     if [ "$free_gb" -lt 10 ] 2>/dev/null; then
         echo -e "${YELLOW}!${NC} Low disk space: ${free_gb}GB free (10GB+ recommended)"
     else

--- a/lakehouse
+++ b/lakehouse
@@ -19,6 +19,19 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Check for GNU tools, when on MacOS
+# See also https://github.com/cloud-helpers/k8s-job-wrappers/tree/main/setGnuTools.sh
+export DF_TOOL="df"
+check_gnutools_on_macos() {
+	DF_TOOL="gdf"
+	if [ ! $(command -v $DF_TOOL) ]
+	then
+        echo -e "${RED}Missing GNU tools on MacOS:${NC}"
+        echo -e "  ${RED}✗${NC} $DF_TOOL"
+		return 1
+	fi
+}
+
 # Check if a command exists
 check_cmd() {
     command -v "$1" >/dev/null 2>&1
@@ -1126,8 +1139,21 @@ cmd_setup() {
     header "LAKEHOUSE SETUP"
     local has_errors=0
 
-    # Step 1: Check prerequisites
-    echo -e "\n${YELLOW}1. Checking prerequisites...${NC}"
+    # Step 1.1: Check for GNU tools, when on MacOS
+	if [ -f /usr/bin/sw_vers ]
+	then	
+		echo -e "\n${YELLOW}1.1. Checking for GNU tools when on MacOS...${NC}"
+		if ! check_gnutools_on_macos; then
+			echo -e "\n${RED}Please install GNU tools on MacOS before continuing.${NC}"
+			echo "See SETUP.md for installation instructions."
+			has_errors=1
+		else
+			echo -e "${GREEN}✓ All required tools installed when on MacOS${NC}"
+		fi
+	fi
+
+    # Step 1.2: Check prerequisites
+    echo -e "\n${YELLOW}1.2. Checking prerequisites...${NC}"
     if ! check_prerequisites; then
         echo -e "\n${RED}Please install missing tools before continuing.${NC}"
         echo "See SETUP.md for installation instructions."
@@ -1232,7 +1258,7 @@ cmd_setup() {
 
     # Step 7: Check disk space
     echo -e "\n${YELLOW}6. Checking disk space...${NC}"
-    local free_gb=$(df -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
+    local free_gb=$(gdf -BG "$PROJECT_ROOT" | tail -1 | awk '{print $4}' | tr -d 'G')
     if [ "$free_gb" -lt 10 ] 2>/dev/null; then
         echo -e "${YELLOW}!${NC} Low disk space: ${free_gb}GB free (10GB+ recommended)"
     else


### PR DESCRIPTION
## Summary
Lands @da115115's macOS contribution (originally #38) against `develop` — macOS ships BSD `df`, which doesn't support `-BG`, so `./lakehouse setup`'s disk-space check fails silently on Macs. Denis's change detects macOS via `/usr/bin/sw_vers` and routes through `gdf` (GNU coreutils) instead.

His two commits are preserved with original authorship; my follow-up fixes two small issues so we can merge cleanly.

## Commits
1. **1ea44c6** (Denis Arnaud) — add `check_gnutools_on_macos`, wire through `$DF_TOOL`
2. **9fe3450** (Denis Arnaud) — fix the literal `gdf` call to use `$DF_TOOL`
3. **a6eb934** (follow-up) — quote `command -v`, replace missing `SETUP.md` reference with `docs/getting-started/installation.md` + `brew install coreutils`

## Why the follow-up
- `[ ! $(command -v $DF_TOOL) ]` is unquoted. When `gdf` isn't installed, it expands to `[ ! ]` — a shell parse error — which breaks exactly the path that's supposed to report "missing GNU tools". Fixed by quoting.
- The error message referenced `SETUP.md`, which doesn't exist in the repo. Point users at the concrete `brew install coreutils` command and the installation doc that does exist.
- Normalized a tab/space indent mix in the block.

## Attribution
Denis's original PR #38 targeted `master`; this one targets `develop` to match the current `feat → develop → master` flow. Closing #38 with a comment pointing here.

## Test plan
- [x] `bash -n lakehouse` passes
- [ ] On a macOS host without `coreutils`, `./lakehouse setup` prints the missing-GNU-tools error and exits non-zero
- [ ] On a macOS host with `coreutils`, `./lakehouse setup` continues past Step 1.1 cleanly
- [ ] On Linux, Step 1.1 is skipped (no `/usr/bin/sw_vers`)

Co-Authored-By: Denis Arnaud <denis.arnaud@decathlon.com>