### PR TITLE
ci: trigger workflow on PR edits and ready-for-review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [master, main, develop]
   pull_request:
     branches: [master, main, develop]
+    # Default types are [opened, synchronize, reopened]. Adding `edited`
+    # so CI also runs when a PR's base branch is changed (e.g. fork PRs
+    # that originally targeted master being retargeted to develop).
+    # Adding `ready_for_review` so draft → ready transitions trigger CI.
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 # Security: Restrict default permissions
 permissions:


### PR DESCRIPTION
## Summary
Add `edited` and `ready_for_review` to the `pull_request` trigger types on `.github/workflows/ci.yml` so CI runs automatically on every PR-level state change — not just on branch pushes.

## Why
Default `pull_request` types are `[opened, synchronize, reopened]`. That leaves two silent gaps:

1. **Base branch retargets.** When a fork PR opened against `master` is retargeted to `develop` (common now that our flow is `feat → develop → master`), CI doesn't run. I hit this manually on #37/#38/#39/#40 — had to `gh run rerun` each one, and #40's original run was stuck `in_progress` so `rerun` refused entirely ("workflow file may be broken").
2. **Draft → ready-for-review.** Draft PRs don't trigger CI under the default types. Promoting a draft doesn't either — means CI only runs after the first push post-promotion.

With `edited` + `ready_for_review` added, both cases trigger CI automatically.

## Trade-off
`edited` also fires on title / description / label edits. Extra CI spend on a few no-op events in exchange for never missing a retarget. Net positive IMO.

## Test plan
- [ ] After merge, retargeting a future PR (or editing its description) triggers a fresh CI run without manual intervention
- [ ] A draft → ready transition triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)