### PR TITLE
ci: harden Airflow Validation against slow archive.apache.org mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,4 +634,4 @@ jobs:
           else
             echo "No DAGs found, skipping validation"
           fi
-        timeout-minutes: 10
+        timeout-minutes: 25

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -18,7 +18,8 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 # Download and install Spark (for spark-submit)
 ENV SPARK_VERSION=4.1.0
 ENV SPARK_HOME=/opt/spark
-RUN curl -fsSL "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz" \
+RUN curl -fsSL --retry 3 --retry-delay 15 --connect-timeout 30 --max-time 1500 \
+    "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz" \
     | tar -xz -C /opt/ \
     && mv /opt/spark-${SPARK_VERSION}-bin-hadoop3 ${SPARK_HOME} \
     && chown -R airflow:root ${SPARK_HOME}


### PR DESCRIPTION
## Problem

Two consecutive CI runs on `develop` (the PR #39 and PR #40 merges from earlier today) timed out at the 10-minute mark while `docker/airflow/Dockerfile` was curling the Spark 4.1.0 tarball from `archive.apache.org`. Re-running the same jobs without code changes both turned green, confirming this is pre-existing flakiness rather than a regression caused by either PR.

Failed runs:
- 25014477236 (1b5cb2a, PR #40 merge) — initially failed, now green after rerun
- 25014456571 (266e6cb, PR #39 merge)

The Spark 4.1.0 tarball is on `archive.apache.org` (the historical mirror) because it was superseded by 4.1.1. `dlcdn.apache.org` would be faster but no longer hosts 4.1.0. The ~400MB download from the archive mirror is borderline-slow on the GitHub Actions runner.

## Fix

Two minimal changes that don't alter runtime behavior:

- `docker/airflow/Dockerfile`: curl gains `--retry 3 --retry-delay 15 --connect-timeout 30 --max-time 1500`. This survives a single transient stall and bounds the download at 25 minutes max.
- `.github/workflows/ci.yml`: `Validate DAGs with Airflow` timeout-minutes bumped from 10 to 25, aligned with the curl ceiling so the workflow never trips before the curl does.

## Test plan

- [x] Diff is +3/-2 across 2 files, no behavior change at runtime
- [x] Same flake reproduced and recovered by rerun on the unfixed dockerfile, confirming the flake mechanism
- [ ] CI on this branch should run cleanly. If the curl succeeds quickly (which is the common case), the timeout bump is unused and benign.

## Out of scope

Switching to a different mirror or bumping to 4.1.1 are bigger changes that warrant their own PRs. This is the smallest fix to stop the flake.